### PR TITLE
v2022.1.x: autoupdater: add key for GitHub actions CI

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -126,6 +126,7 @@
 				good_signatures = 1,
 				pubkeys = {
 					'24f20f0e0d7711181c70c85a76dda08334a96acd631994ace9b61b57a159db7b', -- build.ffda.io
+					'cea1e84bf157d7362287fcd21d13de14634341e3d1ea7038000062743554dc88', -- github-actions-ci
 				},
 			},
 		},


### PR DESCRIPTION
Keep old key off GitHub infrastructure and use a new key for signing the automated releases.

Discussed at Meeting (04.12.2023)

Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit 0717cf8c6455f6219521cf01aacb9616e19fdf6b)