### PR TITLE
dom{18,19}: drop legacy fgw

### DIFF
--- a/domains/dom18.conf
+++ b/domains/dom18.conf
@@ -62,18 +62,6 @@
 								'185.206.210.114 port 10180',
 							},
 						},
-						fgw03 = {
-							key = '8bf46802fd4160040c8fa2752e767315b917cc4424f28ee7a21a7b8f2e917eda',
-							remotes = {
-								'"fgw03.darmstadt.freifunk.net" port 10180',
-							},
-						},
-						fgw04 = {
-							key = 'b34e26e593c1cf73d887c872f94105d413d3460878a9323f016428eb7e7a872f',
-							remotes = {
-								'"fgw04.darmstadt.freifunk.net" port 10180',
-							},
-						},
 					},
 				},
 			},

--- a/domains/dom19.conf
+++ b/domains/dom19.conf
@@ -64,18 +64,6 @@
 								'185.206.210.114 port 10190',
 							},
 						},
-						fgw03 = {
-							key = '8bf46802fd4160040c8fa2752e767315b917cc4424f28ee7a21a7b8f2e917eda',
-							remotes = {
-								'"fgw03.darmstadt.freifunk.net" port 10190',
-							},
-						},
-						fgw04 = {
-							key = 'b34e26e593c1cf73d887c872f94105d413d3460878a9323f016428eb7e7a872f',
-							remotes = {
-								'"fgw04.darmstadt.freifunk.net" port 10190',
-							},
-						},
 					},
 				},
 			},


### PR DESCRIPTION
These Gateways are not in used anymore and were only active in the alpha stage of the external domain infrastructure.