### PR TITLE
ci: fix inclusing newline in docker ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,12 +284,12 @@ jobs:
         uses: freifunk-gluon/action-build@v1
         if: ${{ needs.build-meta.outputs.manifest-beta != '0' }}
         with:
-          container-version: |
+          container-version: >-
             ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           make-target: manifest
           autoupdater-branch: beta
-          release: |
+          release: >-
             ${{ needs.build-meta.outputs.release-version }}
           priority: 1
 


### PR DESCRIPTION
Fix errors when generating beta manifests due to the docker image name containing a newline character.