### PR TITLE
ci: create site-version in build-meta

### DIFF
--- a/.github/build-meta.sh
+++ b/.github/build-meta.sh
@@ -7,6 +7,9 @@ SCRIPT_DIR="$(dirname "$0")"
 # Get Git short hash for repo at $SCRIPT_DIR
 GIT_SHORT_HASH="$(git -C "$SCRIPT_DIR" rev-parse --short HEAD)"
 
+# Get date of last Git commit for repo at $SCRIPT_DIR
+GIT_COMMIT_DATE="$(git -C "$SCRIPT_DIR" log -1 --format=%cd --date=format:'%Y%m%d')"
+
 # Build BROKEN by default. Disable for release builds.
 BROKEN="1"
 
@@ -51,6 +54,10 @@ CONTAINER_VERSION="$(jq -r -e .container.version "$SCRIPT_DIR/build-info.json")"
 # Get Default Release version from site.mk
 DEFAULT_RELEASE_VERSION="$(make --no-print-directory -C "$SCRIPT_DIR/.." -f ci-build.mk version)"
 DEFAULT_RELEASE_VERSION="$DEFAULT_RELEASE_VERSION-$GIT_SHORT_HASH"
+
+# Create site-version from site.mk
+SITE_VERSION="$(make --no-print-directory -C "$SCRIPT_DIR/.." -f ci-build.mk site-version)"
+SITE_VERSION="$SITE_VERSION-ffda-$GIT_COMMIT_DATE-$GIT_SHORT_HASH"
 
 # Enable Manifest generation conditionally
 MANIFEST_STABLE="0"
@@ -151,6 +158,7 @@ echo "build-meta-output=$BUILD_META_TMP_DIR" >> "$BUILD_META_OUTPUT"
 echo "container-version=$CONTAINER_VERSION" >> "$BUILD_META_OUTPUT"
 echo "gluon-repository=$GLUON_REPOSITORY" >> "$BUILD_META_OUTPUT"
 echo "gluon-commit=$GLUON_COMMIT" >> "$BUILD_META_OUTPUT"
+echo "site-version=$SITE_VERSION" >> "$BUILD_META_OUTPUT"
 echo "release-version=$RELEASE_VERSION" >> "$BUILD_META_OUTPUT"
 echo "autoupdater-enabled=$AUTOUPDATER_ENABLED" >> "$BUILD_META_OUTPUT"
 echo "autoupdater-branch=$AUTOUPDATER_BRANCH" >> "$BUILD_META_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,7 +218,8 @@ jobs:
           make-target: update
 
       - name: Build
-        uses: freifunk-gluon/action-build@v1
+        # yamllint disable-line rule:line-length
+        uses: freifunk-gluon/action-build@3a48a4d0db08ff393e08ec3074f1b218ee5ac54b
         id: build-gluon
         with:
           container-version: ${{ needs.build-meta.outputs.container-version }}
@@ -231,6 +232,7 @@ jobs:
           autoupdater-branch: |
             ${{ needs.build-meta.outputs.autoupdater-branch }}
           release: ${{ needs.build-meta.outputs.release-version }}
+          site-version: ${{ needs.build-meta.outputs.site-version }}
 
       - name: Pack and Upload build output
         uses: ./.github/actions/build-artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
         ${{ steps.build-metadata.outputs.container-version }}
       release-version: >-
         ${{ steps.build-metadata.outputs.release-version }}
+      site-version: >-
+        ${{ steps.build-metadata.outputs.site-version }}
       autoupdater-enabled: >-
         ${{ steps.build-metadata.outputs.autoupdater-enabled }}
       autoupdater-branch: >-

--- a/ci-build.mk
+++ b/ci-build.mk
@@ -1,4 +1,7 @@
 include site.mk
 
+site-version:
+	@echo $(FFDA_SITE_VERSION)
+
 version:
 	@echo $(DEFAULT_GLUON_RELEASE)

--- a/site.mk
+++ b/site.mk
@@ -1,4 +1,6 @@
-DEFAULT_GLUON_RELEASE := 2.7~$(shell date '+%Y%m%d')
+FFDA_SITE_VERSION := 2.7
+
+DEFAULT_GLUON_RELEASE := $(FFDA_SITE_VERSION)~$(shell date '+%Y%m%d')
 DEFAULT_GLUON_PRIORITY := 0
 
 # Enable multidomain support


### PR DESCRIPTION
This adds a new output to the build-meta step which generates a custom site-version for use with Gluon.

This is not yet available in Gluon and still needs integration into the build action. Do not merge yet.