### PR TITLE
github: add action for Gluon update

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -1,6 +1,7 @@
 {
     "gluon": {
         "repository": "freifunk-gluon/gluon",
+        "branch": "master",
         "commit": "34ceff6985abdc898e7fa8e461b85299a58e44b1"
     },
     "container": {

--- a/.github/bump-gluon-commit-message.sh
+++ b/.github/bump-gluon-commit-message.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+repo_path="$1"
+old_commit="$2"
+new_commit="$3"
+
+# Check if all arguments are set, print usage otherwise
+if [ -z "$repo_path" ] || [ -z "$old_commit" ] || [ -z "$new_commit" ]; then
+    echo "Usage: bump-gluon-commit-message.sh <repo-path> <old-commit> <new-commit>"
+    exit 1
+fi
+
+# Get short-ref of commits
+old_commit_short="$(git -C "$repo_path" rev-parse --short "$old_commit")"
+new_commit_short="$(git -C "$repo_path" rev-parse --short "$new_commit")"
+
+# Get commit date of new commit (YYYY-MM-DD)
+new_commit_date="$(git -C "$repo_path" show -s --format=%cd --date=short "$new_commit")"
+
+# Get Git log of commit delta
+commit_log="$(git -C "$repo_path" log --oneline --no-decorate "$old_commit".."$new_commit")"
+
+cat <<EOF
+build-info: update Gluon to $new_commit_date
+
+Update Gluon from $old_commit_short to $new_commit_short.
+
+$commit_log
+EOF

--- a/.github/workflows/bump-gluon.yml
+++ b/.github/workflows/bump-gluon.yml
@@ -1,0 +1,106 @@
+# yamllint disable rule:line-length
+---
+name: "Update the Gluon base"
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      site-branch:
+        description: "Site branch to update"
+        required: true
+        default: "master"
+      gluon-commit:
+        description: "Gluon commit to update to"
+        required: true
+        default: "HEAD"
+      skip-pull-request:
+        description: "Skip pull request creation"
+        type: boolean
+        required: true
+        default: false
+
+jobs:
+  update-gluon:
+    runs-on: ubuntu-latest
+    env:
+      GLUON_CHECKOUT_DIR: /tmp/gluon
+      COMMIT_MESSAGE_PATH: /tmp/commit-message.txt
+      BUILD_INFO: .github/build-info.json
+      BUILD_INFO_TMP: .github/build-info.json.tmp
+      COMMIT_NAME: GitHub Actions
+      COMMIT_EMAIL: info@darmstadt.freifunk.net
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.site-branch }}
+
+      - name: Clone Gluon
+        run: |
+          REPO=$(jq -r '.gluon.repository' $BUILD_INFO)
+          git clone https://github.com/${REPO}.git /tmp/gluon
+
+      - name: Checkout Gluon branch
+        run: git -C $GLUON_CHECKOUT_DIR checkout "$(jq -r '.gluon.branch' $BUILD_INFO)"
+
+      - name: Get commit hash
+        id: head-hash
+        run: |
+          BUILD_HASH="$(git -C $GLUON_CHECKOUT_DIR rev-parse ${{ github.event.inputs.gluon-commit }})"
+          echo "hash=$(git -C $GLUON_CHECKOUT_DIR rev-parse "$BUILD_HASH")" >> "$GITHUB_OUTPUT"
+          echo "short-hash=$(git -C $GLUON_CHECKOUT_DIR rev-parse --short "$BUILD_HASH")" >> "$GITHUB_OUTPUT"
+
+      - name: Get build-info.json commit hash
+        id: build-info-hash
+        run: |
+          BUILD_HASH="$(jq -r '.gluon.commit' $BUILD_INFO)"
+          echo "hash=$(git -C $GLUON_CHECKOUT_DIR rev-parse "$BUILD_HASH")" >> "$GITHUB_OUTPUT"
+          echo "short-hash=$(git -C $GLUON_CHECKOUT_DIR rev-parse --short "$BUILD_HASH")" >> "$GITHUB_OUTPUT"
+
+      - name: Update commit-hash
+        if: steps.head-hash.outputs.hash != steps.build-info-hash.outputs.hash
+        run: >-
+          jq --arg commit_hash "${{ steps.head-hash.outputs.hash }}"
+          --indent 4
+          '.gluon.commit = $commit_hash'
+          $BUILD_INFO > $BUILD_INFO_TMP
+
+      - name: Update build-info.json
+        if: steps.head-hash.outputs.hash != steps.build-info-hash.outputs.hash
+        run: mv $BUILD_INFO_TMP $BUILD_INFO
+
+      - name: Generate commit message
+        if: steps.head-hash.outputs.hash != steps.build-info-hash.outputs.hash
+        id: commit-message
+        run: |
+          echo "msg<<EOF" >> "$GITHUB_OUTPUT"
+          ./.github/bump-gluon-commit-message.sh $GLUON_CHECKOUT_DIR ${{ steps.build-info-hash.outputs.hash }} ${{ steps.head-hash.outputs.hash }} >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push changes
+        if: steps.head-hash.outputs.hash != steps.build-info-hash.outputs.hash
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: ${{ steps.commit-message.outputs.msg }}
+          commit_options: '--no-verify --signoff'
+          commit_user_name: ${{ env.COMMIT_NAME }}
+          commit_user_email: ${{ env.COMMIT_EMAIL }}
+          commit_author: ${{ env.COMMIT_NAME }} <${{ env.COMMIT_EMAIL }}>
+          branch: bump-gluon-${{ steps.head-hash.outputs.short-hash }}
+          create_branch: true
+
+      - name: Create pull request
+        if: steps.head-hash.outputs.hash != steps.build-info-hash.outputs.hash && github.event.inputs.skip-pull-request == 'false'
+        run: >-
+          gh pr create
+          -B ${{ github.event.inputs.site-branch }}
+          -H bump-gluon-${{ steps.head-hash.outputs.short-hash }}
+          --fill
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Emit PR creation message
+        if: steps.head-hash.outputs.hash != steps.build-info-hash.outputs.hash && github.event.inputs.skip-pull-request == 'true'
+        run:
+          echo "::notice::Create pull-request at https://github.com/${{ github.repository }}/compare/${{ github.event.inputs.site-branch }}...bump-gluon-${{ steps.head-hash.outputs.short-hash }}?quick_pull=1"


### PR DESCRIPTION
Add a new Action which can be manually triggered to perform a
update of the Gluon base of a given branch.

This will automatically create a new branch, update the commit hash in
build-info.json and create the appropriate PR.

Example: https://github.com/blocktrron/site-ffda/pull/2