### PR TITLE
github ci: also trigger build-tests on pull-requests

### DIFF
--- a/.github/build-meta.sh
+++ b/.github/build-meta.sh
@@ -121,7 +121,7 @@ elif [ "$GITHUB_EVENT_NAME" = "push"  ] && [ "$GITHUB_REF_TYPE" = "tag" ]; then
 	fi
 
 	CREATE_RELEASE="1"
-elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
 	# Workflow Dispatch - autoupdater Branch is testing and disabled
 	AUTOUPDATER_ENABLED="0"
 	AUTOUPDATER_BRANCH="testing"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: "Build Gluon images"
 
 # yamllint disable-line rule:truthy
 on:
+  pull_request:
   push:
   workflow_dispatch:
     inputs:
@@ -163,12 +164,13 @@ jobs:
 
   build:
     needs: [targets, build-meta, host-tools]
-    if: ${{ needs.targets.outputs.targets != '[]' }}
     strategy:
       fail-fast: false
       matrix:
         target: ${{ fromJSON(needs.targets.outputs.targets) }}
     runs-on: ubuntu-22.04
+    if: >
+      needs.targets.outputs.targets != '[]'
     steps:
       - uses: actions/checkout@v4
 
@@ -238,6 +240,9 @@ jobs:
   manifest:
     needs: [build, build-meta, targets]
     runs-on: ubuntu-22.04
+    if: >
+      needs.targets.outputs.targets != '[]' &&
+      github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
 
@@ -349,7 +354,10 @@ jobs:
   deploy:
     needs: [build, build-meta, targets, manifest]
     runs-on: ubuntu-22.04
-    if: ${{ needs.build-meta.outputs.deploy != '0' }}
+    if: >
+      needs.targets.outputs.targets != '[]' &&
+      needs.build-meta.outputs.deploy != '0' &&
+      github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
 
@@ -392,7 +400,10 @@ jobs:
   create-release:
     needs: [build, build-meta, targets, manifest]
     runs-on: ubuntu-22.04
-    if: ${{ needs.build-meta.outputs.create-release != '0' }}
+    if: >
+      needs.targets.outputs.targets != '[]' &&
+      needs.build-meta.outputs.create-release != '0' &&
+      github.event_name == 'push'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Also trigger the CI build pipeline on pull-request actions. This is due
to the CI not running on the branch when triggered from an action. This
happens when bumping Gluon.

As the ressources are not that much of an concern, trigger the
build-test twice in worst-case.