### PR TITLE
build-info: update Gluon to 2023-12-14

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "34ceff6985abdc898e7fa8e461b85299a58e44b1"
+        "commit": "c2dc338abfbebb34dcf62124dc09be85fa88f8ef"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from 34ceff69 to c2dc338a.

```
c2dc338a Merge pull request #3108 from freifunk-gluon/update-ci d9d678cc CI: update filters
359914d1 push_pkg: fix typo in help page (#3106)
57aa3423 Merge pull request #3027 from Kistelini/armsr 2d28a9d9 Merge pull request #3107 from blocktrron/device-delete-all 2dfa8b8d gluon-core: use delete_all instead of iterated delete dc841ea4 mediatek-filogic: add support for Ubiquiti UniFi 6 Plus (#3098) 9e4d8ad4 gluon-core: preserve interface MAC-address configuration (#3102) 19976e26 build: allow overriding GLUON_SITE_VERSION (#3091) 926263b2 docs: add GLUON_FEATURES_standard to multidomain site example (#3038) 87ba9ecd targets.mk: fix inconsistent env variable BROKEN (#2934) 11a04bdb docs: releases/v2023.1.1: add warning and known issue for AVM Fritz!Box 7520 5713a760 Merge pull request #3094 from blocktrron/mtk-x86 7a54ddeb Merge pull request #3093 from herbetom/master-updates c95e897c x86: add MediaTek drivers
8148f6e4 modules: update routing
b9e858f2 modules: update packages
29ea111a modules: update openwrt
32256efd github: release docker container for next branch (#3086) a4d5955c Merge pull request #3012 from freifunk-gluon/lua-bit32 2b27b688 new target: armsr
1b12e7c5 treewide: replace luabitops with lua-bit32 c870e9f9 gluon-mesh-babel: remove luabitop dependency
```