### PR TITLE
ci update-gluon: format commit log as code

### DIFF
--- a/.github/bump-gluon-commit-message.sh
+++ b/.github/bump-gluon-commit-message.sh
@@ -27,5 +27,7 @@ build-info: update Gluon to $new_commit_date
 
 Update Gluon from $old_commit_short to $new_commit_short.
 
+\`\`\`
 $commit_log
+\`\`\`
 EOF


### PR DESCRIPTION
Format the commit-log in the update commit-message as a markdown code-block.

This improves the formatting in the GitHub pull-request.