### PR TITLE
image-customization: bcm27xx: remove pci packages

### DIFF
--- a/image-customization.lua
+++ b/image-customization.lua
@@ -143,8 +143,6 @@ end
 
 -- Include all custom packages for RaspberryPi
 if target('bcm27xx') then
-	packages(pkgs_pci)
-	packages(pkgs_pci_net)
 	packages(pkgs_usb_hid)
 	packages(pkgs_usb_net)
 	packages(pkgs_usb_serial)


### PR DESCRIPTION
the kmod-bnx2 package doesn't seem to be available for bcm27xx-bcm2708 and we don't need it