### PR TITLE
image-customization: unbreak NWA55AXE

### DIFF
--- a/image-customization.lua
+++ b/image-customization.lua
@@ -161,7 +161,8 @@ if target('x86') then
 	packages(pkgs_usb_storage)
 end
 
--- Network-activated setup-mode for NWA55AXE
+-- the Network-activated setup-mode allows us to unbreak the device
 if device({'zyxel-nwa55axe'}) then
+	broken(false)
 	packages({'ffda-network-setup-mode'})
 end


### PR DESCRIPTION
The reason the device is marked as broken is the missing button. We've got the network-activated setup mode package. Therefore we can overwrite the broken Flag from Gluon.