### PR TITLE
build-info: update Gluon to 2024-01-05

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "db0e7bdaff7a13ede8d6c7651bcda5f05b31b2ad"
+        "commit": "247e78161755e141854c222c903271ef8d5692ce"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from db0e7bda to 247e7816.

```
247e7816 docs, readme: Gluon v2023.2 (#3144)
4aba3920 docs: add v2023.2 release notes (#3068)
06d54771 Improvements to image customization docs (#3127)
97990863 Merge pull request #3142 from blocktrron/release-backports
07eeca64 netifd: system-linux: fix race condition in netlink socket error handing
4ed9c19c dropbear: increase default receive window size
d125c006 Merge pull request #3140 from neocturne/readthedocs-config
dbf02e06 readthedocs: change file extension to yaml
82a99f96 readthedocs: update to Python 3.11
dba38f3e Merge pull request #3132 from T-X/pr-fix-README
102d5d48 docs: remove unrelated draft link to open-mesh.org in README
de21d556 docs: fix headings in README.md
d517e0ff docs: Add description about what gluon is (#3035)
3df97e87 ath79-generic: add support for Sophos AP55 (#3116)
a60fdd4d ath79-generic: add support for Sophos AP100 (#3121)
38f7e106 license: add title (#3112)
fe37d977 docs site: fix image-customization filename (#3123)
1523a2f4 github: build-gluon: cancel obsolete in progress workflows for PRs (#3115)
```