### PR TITLE
github: disable compression for build-output

### DIFF
--- a/.github/actions/build-artifact/action.yml
+++ b/.github/actions/build-artifact/action.yml
@@ -18,5 +18,6 @@ runs:
       with:
         name: ${{ inputs.hardware-target }}
         path: build-artifact-workdir
+        compression-level: 0
     - run: rm -rf "$GITHUB_WORKSPACE/build-artifact-workdir"
       shell: bash

--- a/.github/actions/build-artifact/action.yml
+++ b/.github/actions/build-artifact/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
     - run: tar -cJf "$GITHUB_WORKSPACE/build-artifact-workdir/output.tar.xz" -C ${{ inputs.gluon-path }}/output images packages debug
       shell: bash
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.hardware-target }}
         path: build-artifact-workdir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         run: bash .github/build-meta.sh
 
       - name: Create Artifact of build-meta
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-meta
           path: ${{ steps.build-metadata.outputs.build-meta-output }}
@@ -158,7 +158,7 @@ jobs:
           --posix -C "gluon-gha-data/gluon" openwrt
 
       - name: Archive build output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openwrt
           path: "gluon-gha-data/openwrt"
@@ -199,7 +199,7 @@ jobs:
         run: cat /proc/meminfo
 
       - name: Download prepared OpenWrt
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: openwrt
           path: "gluon-gha-data/openwrt"
@@ -250,7 +250,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: "gluon-gha-data/gluon-output"
 
@@ -262,7 +262,7 @@ jobs:
           path: 'gluon-gha-data/gluon'
 
       - name: Download prepared OpenWrt
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: openwrt
           path: "gluon-gha-data/openwrt"
@@ -349,7 +349,7 @@ jobs:
           -C gluon-gha-data/gluon/output/images/sysupgrade -T -
 
       - name: Archive output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: manifest-signed
           path: gluon-gha-data/artifact-out
@@ -365,7 +365,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: "gluon-gha-data/artifact-download"
 
@@ -413,7 +413,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: "gluon-gha-data/artifact-download"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,7 @@ jobs:
         with:
           name: openwrt
           path: "gluon-gha-data/openwrt"
+          compression-level: 0
 
 
   build:


### PR DESCRIPTION
Bump the download and upload artifacts actions to v4. This will allow us
to specify the compression-level and thus reduce the duration of the
build pipeline.


---

Disable compression for the target as well as host-tools build-output.
We already compress the resulting tar archive, so we don't need to waste
more time on compressing it again.