### PR TITLE
github ci: link testing release automatically

### DIFF
--- a/.github/build-meta.sh
+++ b/.github/build-meta.sh
@@ -19,6 +19,9 @@ DEPLOY="0"
 # Don't release by default. Enable for tags.
 CREATE_RELEASE="0"
 
+# Don't link release by default. Enable for testing.
+LINK_RELEASE="0"
+
 # Target whitelist
 if [ -n "$WORKFLOW_DISPATCH_TARGETS" ]; then
 	# Get targets from dispatch event
@@ -101,6 +104,7 @@ elif [ "$GITHUB_EVENT_NAME" = "push"  ] && [ "$GITHUB_REF_TYPE" = "tag" ]; then
 
 		RELEASE_VERSION="$(echo "$GITHUB_REF_NAME" | tr '-' '~')"
 		DEPLOY="1"
+		LINK_RELEASE="1"
 	elif [[ "$GITHUB_REF_NAME" =~ $RELEASE_TAG_RE ]]; then
 		# Stable release - autoupdater Branch is stable and enabled
 		AUTOUPDATER_ENABLED="1"
@@ -168,6 +172,7 @@ echo "manifest-beta=$MANIFEST_BETA" >> "$BUILD_META_OUTPUT"
 echo "manifest-testing=$MANIFEST_TESTING" >> "$BUILD_META_OUTPUT"
 echo "sign-manifest=$SIGN_MANIFEST" >> "$BUILD_META_OUTPUT"
 echo "deploy=$DEPLOY" >> "$BUILD_META_OUTPUT"
+echo "link-release=$LINK_RELEASE" >> "$BUILD_META_OUTPUT"
 echo "create-release=$CREATE_RELEASE" >> "$BUILD_META_OUTPUT"
 echo "target-whitelist=$TARGET_WHITELIST" >> "$BUILD_META_OUTPUT"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,8 @@ jobs:
         ${{ steps.build-metadata.outputs.create-release }}
       deploy: >-
         ${{ steps.build-metadata.outputs.deploy }}
+      link-release: >-
+        ${{ steps.build-metadata.outputs.link-release }}
       target-whitelist: >-
         ${{ steps.build-metadata.outputs.target-whitelist }}
     env:
@@ -400,6 +402,33 @@ jobs:
         # ToDo: Remove 'ffda' site-code and move to build-meta
         # yamllint disable-line rule:line-length
         run: rsync -avzP -e "ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key -oIdentitiesOnly=yes" "gluon-gha-data/gluon-output/output/packages/gluon-ffda-${{ needs.build-meta.outputs.release-version }}" "firmware@www1.darmstadt.freifunk.net:/srv/firmware/modules/"
+
+
+  link-release:
+    needs: [build, build-meta, targets, manifest, deploy]
+    runs-on: ubuntu-22.04
+    if: >
+      needs.targets.outputs.targets != '[]' &&
+      needs.build-meta.outputs.deploy != '0' &&
+      needs.build-meta.outputs.link-release != '0' &&
+      github.event_name == 'push'
+    steps:
+      - name: Save SSH Key for deployment
+        run: >
+          mkdir -p ~/.ssh &&
+          echo "${{ secrets.GHA_FFDA_BUILD_DEPLOY_SSH_KEY }}" >
+          ~/.ssh/deploy_key && chmod 600 ~/.ssh/deploy_key
+      - name: Link Release
+        env:
+          RELEASE_VERSION: ${{ needs.build-meta.outputs.release-version }}
+          AUTOUPDATER_BRANCH: ${{ needs.build-meta.outputs.autoupdater-branch }}
+        # yamllint disable rule:line-length
+        run: >
+          ssh -i ~/git/freifunk/ci-key/id_ci
+          -oIdentitiesOnly=yes
+          firmware@www1.darmstadt.freifunk.net
+          "ln -n -f -s /srv/firmware/images/$RELEASE_VERSION /srv/firmware/images/$AUTOUPDATER_BRANCH"
+        # yamllint enable rule:line-length
 
 
   create-release:


### PR DESCRIPTION
This automatically enables testing releases for the firmware selector and autoupdater after they are deployed on the firmware download server.

Beta and Stable releases are not affected by this change.