### PR TITLE
build-info: update Gluon to 2024-01-11

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "247e78161755e141854c222c903271ef8d5692ce"
+        "commit": "10721f6e23184a1ca501ba35173e49cd90b1bfd3"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from 247e7816 to 10721f6e.

```
10721f6e ath79-generic: add support for Ubiquiti UniFi Swiss Army Knife Ultra (#3149)
5eb15acd Merge pull request #2465 from freifunk-gluon/respondd-fastd-method
d9c6463a Merge pull request #3156 from blocktrron/upstream-master-updates
f0f98c5a modules: update packages
97843d56 modules: update openwrt
9fc4918c gluon-status-page: update minified JavaScript
067dc3ed gluon-status-page: expose method for VPN peers
0e102e79 gluon-mesh-vpn-fastd: Expose negotiated method
1ba17d6f ramips-mt7621: add support for D-Link COVR X1860 a1 (#3153)
c4bbc1e2 modules: update openwrt (#3152)
113f7756 treewide: purge gluon-mesh-babel (#3105)
13dedfc2 labeler: update "continuous integration" label name (#3151)
4714f5d2 Merge pull request #3150 from blocktrron/ci-site-drop-version
1ec99435 contrib: drop Gluon version from CI site
01044738 build(deps): bump actions/upload-artifact from 3 to 4 (#3134)
59f59dc7 ramips-mt76x8: add xiaomi-mi-ra75 (#3122)
7e0e16f4 Merge pull request #3145 from herbetom/master-updates
5f9436f4 modules: update routing
46c22477 modules: update packages
d5d28967 modules: update openwrt
e0d649c3 gluon-mesh-vpn-tunneldigger: drop package (#3109)
d755d8b9 ath79-generic: add support for Sophos AP15 (#3126)
d5415159 build(deps): bump sphinx from 7.1.2 to 7.2.6 in /docs (#3133)
ba00b6e5 build(deps): bump docker/setup-qemu-action from 2 to 3 (#3135)
020c07b6 build(deps): bump docker/setup-buildx-action from 2 to 3 (#3137)
c74663f4 build(deps): bump docker/metadata-action from 5.2.0 to 5.4.0 (#3138)
```