### PR TITLE
image-customization: drop update-stabilizer

### DIFF
--- a/image-customization.lua
+++ b/image-customization.lua
@@ -22,7 +22,6 @@ features({
 packages({
 	'iwinfo',
 	'respondd-module-airtime',
-	'ffda-update-stabilizer',
 })
 
 -- Packages and features for devices which are not flagged as tiny


### PR DESCRIPTION
Now that we have a beta firmware for all to-be-stabilized devices, we can remove this package again. This allows users to select non-stable autoupdater branches persistently again.