### PR TITLE
build-info: switch branch

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -1,7 +1,7 @@
 {
     "gluon": {
         "repository": "freifunk-gluon/gluon",
-        "branch": "master",
+        "branch": "v2023.2.x",
         "commit": "247e78161755e141854c222c903271ef8d5692ce"
     },
     "container": {


### PR DESCRIPTION
We track GLuon release branch. This allows to use the bump-gluon action.