### PR TITLE
build-info: update Gluon to 2024-01-16

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "247e78161755e141854c222c903271ef8d5692ce"
+        "commit": "bfbefa4580d1162b2766c6e685d85b970d0c9680"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from 247e7816 to bfbefa45.

```
bfbefa45 Merge pull request #3161 from blocktrron/v2023.2.x-backports
bbd601b9 ath79-generic: add support for Ubiquiti UniFi Swiss Army Knife Ultra (#3149)
c2815311 ramips-mt7621: add support for D-Link COVR X1860 a1 (#3153)
c42f3975 gluon-status-page: update minified JavaScript
1b2da046 gluon-status-page: expose method for VPN peers
f83fe37c gluon-mesh-vpn-fastd: Expose negotiated method
694e7f6d contrib: drop Gluon version from CI site
5cdc4513 Merge pull request #3157 from blocktrron/v2023.2.x-updates
0f240ddd modules: update routing
09459323 modules: update packages
0982c156 modules: update openwrt
```