### PR TITLE
github bump-message: escape commit lock using tilde

### DIFF
--- a/.github/bump-gluon-commit-message.sh
+++ b/.github/bump-gluon-commit-message.sh
@@ -27,7 +27,7 @@ build-info: update Gluon to $new_commit_date
 
 Update Gluon from $old_commit_short to $new_commit_short.
 
-\`\`\`
+~~~
 $commit_log
-\`\`\`
+~~~
 EOF


### PR DESCRIPTION
This should fix the loss of backticks when echoing the script output to the GHA result.

See

~~~
I'm a text in a codeblock!
~~~