### PR TITLE
build-info: update Gluon to 2024-01-19

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "10721f6e23184a1ca501ba35173e49cd90b1bfd3"
+        "commit": "43beae558596d733eb96542be43ad04acc373278"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from 10721f6e to 43beae55.

~~~
43beae55 mac80211: silence warning for missing rate information (#3163)
141e0472 Merge pull request #3164 from blocktrron/upstream-master-updates
258f3c12 modules: update packages
f0bf84a7 modules: update openwrt
~~~