### PR TITLE
build-info: update Gluon to 2024-01-23

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "bfbefa4580d1162b2766c6e685d85b970d0c9680"
+        "commit": "19c2441e9bf25b2407c8cebbcce7ca8fe1012c35"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from bfbefa45 to 19c2441e.

```
19c2441e Merge pull request #3168 from blocktrron/v2023.2.1-rn
3c3a6a92 docs, readme: Gluon v2023.2.1
cf970dd8 docs: add v2023.2.1 release notes
8619f4b1 Merge pull request #3166 from blocktrron/v2023.2.x-updates
51aa8508 mac80211: silence warning for missing rate information (#3167)
707e2b77 modules: update packages
9f65c19c modules: update openwrt
```