### PR TITLE
build-info: switch to release docker image tag

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -5,7 +5,7 @@
         "commit": "19c2441e9bf25b2407c8cebbcce7ca8fe1012c35"
     },
     "container": {
-        "version": "master"
+        "version": "v2023.2.1"
     },
     "build": {
         "targets": [


### PR DESCRIPTION
Switch the docker image to the latest image based on a Gluon release tag.

This ensures the container is consistent if built in the future.