### PR TITLE
github build: update Cache action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Restore Cache
         id: restore-cache-tools
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: gluon-gha-data/gluon/openwrt
           key: openwrt-${{ steps.cache-key.outputs.cache-key }}
@@ -146,7 +146,7 @@ jobs:
         if: >
           github.ref_type != 'tag' &&
           steps.restore-cache-tools.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: gluon-gha-data/gluon/openwrt
           key: openwrt-${{ steps.cache-key.outputs.cache-key }}


### PR DESCRIPTION
Update cache action due to deprecation of Node16.

No functional changes.

Link: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/