### PR TITLE
github build: update Cache action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Restore Cache
         id: restore-cache-tools
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: gluon-gha-data/gluon/openwrt
           key: openwrt-${{ steps.cache-key.outputs.cache-key }}
@@ -144,7 +144,7 @@ jobs:
         if: >
           github.ref_type != 'tag' &&
           steps.restore-cache-tools.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: gluon-gha-data/gluon/openwrt
           key: openwrt-${{ steps.cache-key.outputs.cache-key }}


### PR DESCRIPTION
Update cache action due to deprecation of Node16.

No functional changes.

Link: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit 6d72b44614413520302270ced9632dab987524b1)