### PR TITLE
build-info: update Gluon to 2024-02-11

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "43beae558596d733eb96542be43ad04acc373278"
+        "commit": "f3a2bcd166bd70d6b0dbd5720dad2c7c85a79104"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from 43beae55 to f3a2bcd1.

~~~
f3a2bcd1 Merge pull request #3184 from herbetom/master-updates 3df20a38 modules: update gluon
19910ad0 modules: update routing
830c60cc modules: update packages
9ffa705b modules: update openwrt
d8b7d4b3 Merge pull request #3172 from blocktrron/v2023.2.1-master-releasenotes 
07175dc docs, readme: Gluon v2023.2.1
0859bd7a docs: add v2023.2.1 release notes
594a05e0 docs: add v2023.1.2 release notes
b4807e75 tools flex: disable parallel build (#3169)
~~~