### PR TITLE
build-info: update Gluon to 2024-02-21

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "f3a2bcd166bd70d6b0dbd5720dad2c7c85a79104"
+        "commit": "e545756939d07578d40f2ef035d31bdcf495c873"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from f3a2bcd1 to e5457569.

~~~
e5457569 Merge pull request #3186 from Djfe/drop_old_aliases
4d504e7d ath79-generic: add support for D-Link DAP-2680 (#3190)
8e2dee1c docs: fix typo in v2023.2 release notes (#3195)
97b9fcc9 net vxlan: don't learn non-unicast L2 destinations (#3192)
47eaf9e8 generic: disable kernel SWAP support (#3189)
7fac690f targets: docs: Make target files and OEMs more consistent
4e2bf620 targets: drop manifest aliases for previous releases
~~~