### PR TITLE
github: bump-gluon: bump stefanzweifel/git-auto-commit-action to v5

### DIFF
--- a/.github/workflows/bump-gluon.yml
+++ b/.github/workflows/bump-gluon.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Commit and push changes
         if: steps.head-hash.outputs.hash != steps.build-info-hash.outputs.hash
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: ${{ steps.commit-message.outputs.msg }}
           commit_options: '--no-verify --signoff'


### PR DESCRIPTION
The main change is Node 20 instead of 16.

https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v5.0.0