### PR TITLE
[v2023.2.x] build-info: update Gluon to 2024-02-27

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "396e8f38841de3c30e85bbee061d5f0e3afebc13"
+        "commit": "83ad9d3262baa43ee69ebaa7fe325c6daed0f4bb"
     },
     "container": {
         "version": "v2023.2.1"


### PR DESCRIPTION
Update Gluon from 396e8f38 to 83ad9d32.

```
83ad9d32 Merge pull request #3206 from blocktrron/v2023.2.x-updates
6006526d modules: update gluon
b42ba412 modules: update routing
75e70421 modules: update packages
30e2349b modules: update openwrt
64cd0912 Merge pull request #3198 from blocktrron/v2023.2.x-updates
956fc7ec modules: update packages
c769d70f modules: update openwrt
```