### PR TITLE
build-info: update Gluon to 2024-02-27

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "e545756939d07578d40f2ef035d31bdcf495c873"
+        "commit": "8b30e19b03df22548ca1a76d7d0862393a2e0a6b"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from e5457569 to 8b30e19b.

~~~
8b30e19b Merge pull request #3207 from bobidle/fix_recovery_tool_url
6e24d08d Merge pull request #3205 from blocktrron/upstream-master-updates
90b97243 docs: fix AVM Recovery Tool url in v2023.1.1 release notes
b9e921e7 modules: update packages
1e8ea5bf modules: update openwrt
7446034f Merge pull request #3197 from blocktrron/upstream-master-updates
1d42af2a ath79-generic: add support for D-Link DAP-2695 (#3194)
7dbb1d3c modules: update packages
3f329643 modules: update openwrt
~~~