### PR TITLE
build-info: remove duplicate target and sort

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -15,16 +15,15 @@
             "ipq806x-generic",
             "lantiq-xrx200",
             "lantiq-xway",
-            "ipq806x-generic",
             "mediatek-filogic",
             "mpc85xx-p1010",
             "mpc85xx-p1020",
-            "ramips-mt76x8",
             "ramips-mt7620",
             "ramips-mt7621",
+            "ramips-mt76x8",
             "rockchip-armv8",
-            "x86-generic",
-            "x86-64"
+            "x86-64",
+            "x86-generic"
         ]
     }
 }


### PR DESCRIPTION
ipq806x-generic appeared two times in the list

0-9a-z is the more common sorting strategy