### PR TITLE
build-info: update Gluon to 2024-03-14

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "ca591ac5308cb8b2f444d0a2a8dab9145115c03d"
+        "commit": "6036aa6d455621ff12f098af2767cd66024ab600"
     },
     "container": {
         "version": "v2023.2.1"


### PR DESCRIPTION
Update Gluon from ca591ac5 to 6036aa6d.

This equals the v2023.2.2 release-tag

```
6036aa6d Merge pull request #3200 from blocktrron/pr-v2023.2.2
a2ed18c5 docs readme: Gluon v2023.2.2
32adf555 docs: add v2023.2.2 release notes
960bc8dd Merge pull request #3225 from blocktrron/v2023.2.x-updates
1299e15e generic: disable libpfring
06982071 modules: update packages
32acb61d modules: update openwrt
```