### PR TITLE
build-info: update Gluon to 2024-03-23

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "8b30e19b03df22548ca1a76d7d0862393a2e0a6b"
+        "commit": "49978ea8d7547843b8764bc448a835a7876056d9"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from 8b30e19b to 49978ea8.

~~~
49978ea8 Merge pull request #3233 from blocktrron/upstream-master-updates
b4585e45 modules: update packages
278bc01b modules: update openwrt
dd56c00c ath79-generic: add support for NETGEAR WNDRMAC v2
2689bcdd Merge pull request #3227 from herbetom/master-updates
0c4f7c45 modules: update packages
89800023 modules: update openwrt
d4847b69 Merge pull request #3226 from blocktrron/pr-v2023.2.2-master
fe025177 docs readme: Gluon v2023.2.2
4d49942b docs: add v2023.2.2 release notes
c0a0b07b Merge pull request #3158 from blocktrron/bump-labeler
eb744fe5 Merge pull request #3224 from blocktrron/upstream-master-updates
1ff17a6a generic: disable libpfring
8aa94074 modules: update packages
85f1fa87 modules: update openwrt
7669df78 scripts: image_customization_lib.lua: fail build without valid customization file (#3219)
f3cc781b Merge pull request #3215 from herbetom/master-updates
ea5ebd9c mac80211: add AQL support for broadcast packets (#3208)
0bbe55ca gluon-ebtables-limit-arp: stop for autoupdater (#3162)
c905ea50 build(deps): bump docker/metadata-action from 5.4.0 to 5.5.1 (#3179)
575a67b3 build(deps): bump korthout/backport-action from 2.1.1 to 2.4.1 (#3177)
981998e2 github: bump paths-filter version (#3180)
3d182a26 modules: update packages
a39d4c93 modules: update openwrt
b64ebad0 ath79-generic: dir-825-b1 drop class tiny (#3210)
2d250b2c Merge pull request #3201 from neocturne/selinux-container
a74de410 build(deps): bump docker/login-action (#3209)
fc424332 Merge pull request #3187 from Djfe/drop-vdsl-packages
e5593d52 ipq40xx-generic: remove all dsl related packages
b287e6f3 lantiq-xrx200: remove obsolete dsl-app again
9ccd353e scripts/container.sh: fix rootless Podman on systems with SELinux
35dee4e1 github: update labeler configuration to v5
60d1e9bf build(deps): bump actions/labeler from 4 to 5
~~~