### PR TITLE
build-info: update Gluon to 2024-05-11

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "6036aa6d455621ff12f098af2767cd66024ab600"
+        "commit": "82822a56a1b4288abac4c2b4319150a3016188ff"
     },
     "container": {
         "version": "v2023.2.1"


### PR DESCRIPTION
Update Gluon from 6036aa6d to 82822a56.

```
82822a56 Merge pull request #3256 from blocktrron/v2023.2.x-updates
fefdbd74 modules: update routing
e19f183c modules: update packages
32ebeb0e modules: update openwrt
00160f5b gluon-core: lua: wireless: use libiwinfo-lua for find_phy() (#3239)
83fb430e ath79-generic: add support for NETGEAR WNDRMAC v2 (#3232)
```