### PR TITLE
build-info: update Gluon to 2024-06-09

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "e0b723cef78b77be133afe0042e51eed9888d9f7"
+        "commit": "9965def79ef9e5a9b2794a9567cd8e5f4a064c92"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from e0b723ce to 9965def7.

~~~
9965def7 Merge pull request #3274 from blocktrron/upstream-master-updates
a79793b3 modules: update routing
628b9043 modules: update packages
66902c71 modules: update openwrt
~~~