### PR TITLE
build-info: update Gluon to 2024-06-09

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "82822a56a1b4288abac4c2b4319150a3016188ff"
+        "commit": "068cca0e7a558ff080bec1b4804223bf92db8bdf"
     },
     "container": {
         "version": "v2023.2.1"


### PR DESCRIPTION
Update Gluon from 82822a56 to 068cca0e.

```
068cca0e mpc85xx-p1020: add support for Hewlett-Packard MSM460 (#3275)
d0226591 Merge pull request #3273 from blocktrron/v2023.2.x-updates
71c91b9c modules: update routing
75c6d44b modules: update packages
bee44b93 modules: update openwrt
34b1eed7 ath79-generic: TP-Link Archer C7 v2: Fix region selection for factory image (#3260)
```