### PR TITLE
site ci: obtain site-version from latest tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,9 @@ jobs:
     name: Determine build-meta
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
 
       - name: Get build-metadata
         id: build-metadata

--- a/site.mk
+++ b/site.mk
@@ -1,4 +1,4 @@
-FFDA_SITE_VERSION := 3.1
+FFDA_SITE_VERSION := $(shell git describe --tags --abbrev=0 | sed 's/-.*//')
 
 DEFAULT_GLUON_RELEASE := $(FFDA_SITE_VERSION)~$(shell date '+%Y%m%d')
 DEFAULT_GLUON_PRIORITY := 0


### PR DESCRIPTION
Site-version had to be set in the past manually, even when tagging a release. As this is not done every time, just parse it from the latest tag on the history relative from the current commit.

This ensures the site- and firmware-version are always determined from git tags when built from the CI.