### PR TITLE
build-info: update Gluon to 2024-06-10

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "9965def79ef9e5a9b2794a9567cd8e5f4a064c92"
+        "commit": "10728bc8a8ae53f0de8e78ef26497b3aa8826b5a"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from 9965def7 to 10728bc8.

This fixes broken boot on Enterasys WS-AP3710i devices.

~~~
10728bc8 Merge pull request #3277 from blocktrron/upstream-master-updates
50c1bceb modules: update packages
ec83aec4 modules: update openwrt
068c12b5 docs: site: pubkey_privacy works for wireguard (#3254)
ff91e601 ramips-mt7621: add support for D-Link DAP-1620 B1 (#3124)
a2e5767f build(deps): bump sphinx from 7.2.6 to 7.3.7 in /docs (#3249)
439dd1f2 build(deps): bump docker/login-action (#3269)
0ffa3f8f build(deps): bump korthout/backport-action from 2.5.0 to 3.0.2 (#3270)
~~~