### PR TITLE
site ci: retrieve tags from directory of Makefile

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -1,4 +1,5 @@
-FFDA_SITE_VERSION := $(shell git describe --tags --abbrev=0 | sed 's/-.*//')
+FFDA_SITE_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+FFDA_SITE_VERSION := $(shell git -C $(FFDA_SITE_DIR) describe --tags --abbrev=0 | sed 's/-.*//')
 
 DEFAULT_GLUON_RELEASE := $(FFDA_SITE_VERSION)~$(shell date '+%Y%m%d')
 DEFAULT_GLUON_PRIORITY := 0


### PR DESCRIPTION
Retrieve the git tag relative to the directory the Makefile invokes the git command. Previously, the directory git was working in was the one of the root Makefile. When invoked from Gluon directly without using the CI tooling, the tag retrieved would be obtained from the Gluon tree, not the site tree.

Fixes: d8b10353b6c8 ("site ci: retrieve tags from directory of Makefile")