### PR TITLE
site ci: obtain site-version from latest tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,14 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
+      - name: Fetch upstream tags
+        # yamllint disable rule:line-length
+        if: ${{ github.repository != 'freifunk-darmstadt/site-ffda' }}
+        run: |
+          git remote add upstream https://github.com/freifunk-darmstadt/site-ffda.git
+          git fetch upstream --tags
+        # yamllint enable rule:line-length
+
       - name: Get build-metadata
         id: build-metadata
         run: bash .github/build-meta.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,9 @@ jobs:
     name: Determine build-meta
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
 
       - name: Get build-metadata
         id: build-metadata

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,12 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
+      - name: Set Timezone
+        run: sudo timedatectl set-timezone Europe/Berlin
+
+      - name: Show current Timezone settings
+        run: timedatectl status
+
       - name: Fetch upstream tags
         # yamllint disable rule:line-length
         if: ${{ github.repository != 'freifunk-darmstadt/site-ffda' }}

--- a/site.mk
+++ b/site.mk
@@ -1,4 +1,4 @@
-FFDA_SITE_VERSION := 3.0.3
+FFDA_SITE_VERSION := $(shell git describe --tags --abbrev=0 | sed 's/-.*//')
 
 DEFAULT_GLUON_RELEASE := $(FFDA_SITE_VERSION)~$(shell date '+%Y%m%d')
 DEFAULT_GLUON_PRIORITY := 0

--- a/site.mk
+++ b/site.mk
@@ -1,4 +1,5 @@
-FFDA_SITE_VERSION := $(shell git describe --tags --abbrev=0 | sed 's/-.*//')
+FFDA_SITE_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+FFDA_SITE_VERSION := $(shell git -C $(FFDA_SITE_DIR) describe --tags --abbrev=0 | sed 's/-.*//')
 
 DEFAULT_GLUON_RELEASE := $(FFDA_SITE_VERSION)~$(shell date '+%Y%m%d')
 DEFAULT_GLUON_PRIORITY := 0


### PR DESCRIPTION
Site-version had to be set in the past manually, even when tagging a
release. As this is not done every time, just parse it from the latest
tag on the history relative from the current commit.

This ensures the site- and firmware-version are always determined from
git tags when built from the CI.

Signed-off-by: David Bauer <mail@david-bauer.net>
