### PR TITLE
site ci: fetch tags from upstream repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,14 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
+      - name: Fetch upstream tags
+        # yamllint disable rule:line-length
+        if: ${{ github.repository != 'freifunk-darmstadt/site-ffda' }}
+        run: |
+          git remote add upstream https://github.com/freifunk-darmstadt/site-ffda.git
+          git fetch upstream --tags
+        # yamllint enable rule:line-length
+
       - name: Get build-metadata
         id: build-metadata
         run: bash .github/build-meta.sh


### PR DESCRIPTION
If the action is run in a fork, the versioning might be off as tags are most likely not to be updated in the fork.

Fix this by fetching the tags from the upstream repo in case the action is run in the context of a fork.