### PR TITLE
site ci: set timezone in build-meta step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,12 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
+      - name: Set Timezone
+        run: sudo timedatectl set-timezone Europe/Berlin
+
+      - name: Show current Timezone settings
+        run: timedatectl status
+
       - name: Get build-metadata
         id: build-metadata
         run: bash .github/build-meta.sh


### PR DESCRIPTION
Change the system timezone in the build-meta step to Europe/Berlin. This ensures the date of a testing firmware is determined for the correct timezone Freifunk Darmstadt is located in.