### PR TITLE
site: set fallback version

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -1,5 +1,8 @@
 FFDA_SITE_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-FFDA_SITE_VERSION := $(shell git -C $(FFDA_SITE_DIR) describe --tags --abbrev=0 | sed 's/-.*//')
+FFDA_SITE_VERSION_GIT := $(shell git -C $(FFDA_SITE_DIR) describe --tags --abbrev=0 | sed 's/-.*//')
+
+FFDA_SITE_VERSION_FALLBACK := 3.1
+FFDA_SITE_VERSION := $(if $(FFDA_SITE_VERSION_GIT),$(FFDA_SITE_VERSION_GIT),$(FFDA_SITE_VERSION_FALLBACK))
 
 DEFAULT_GLUON_RELEASE := $(FFDA_SITE_VERSION)~$(shell date '+%Y%m%d')
 DEFAULT_GLUON_PRIORITY := 0


### PR DESCRIPTION
Add a fallback version, which is applied in case the site is built without tags fetched. This ensures the version string is not empty.

The fallback-version is set when branching a release off. It is et to the minor-version only. The patch version is omitted, like it is currently done for testing images.