### PR TITLE
build-info: update Gluon to 2024-06-14

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "068cca0e7a558ff080bec1b4804223bf92db8bdf"
+        "commit": "ec72498a44c66a512ceeb45d89cf9ea8f4e5eda8"
     },
     "container": {
         "version": "v2023.2.1"


### PR DESCRIPTION
Update Gluon from 068cca0e to ec72498a.

```
ec72498a Merge pull request #3279 from blocktrron/v2023.2.3-release-notes
26118d79 Merge pull request #3278 from blocktrron/v2023.2.x-updates
5b7b636d Merge pull request #3276 from blocktrron/v2023.2.x-update-actions
cc4cc84e github labels: update labeler action to v5
9adddafc docs readme: Gluon v2023.2.3
9df7bdf8 docs: add v2023.2.3 release notes
348ec72d modules: update packages
b7971355 modules: update openwrt
ebb5a2bc github: update build-containr workflow actions
d24a4edc github: bump paths-filter version (#3180)
318f17da github: update upload-artifact action
```