### PR TITLE
github: update branch-name for master

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -1,11 +1,11 @@
 {
     "gluon": {
         "repository": "freifunk-gluon/gluon",
-        "branch": "master",
+        "branch": "main",
         "commit": "10728bc8a8ae53f0de8e78ef26497b3aa8826b5a"
     },
     "container": {
-        "version": "master"
+        "version": "main"
     },
     "build": {
         "targets": [

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Gluon site configuration to build firmware for Darmstadt.
 ### Branches
 
 * `master`:
-    * matches Gluons `master` branch
+    * matches Gluons `main` branch
     * basis for the next release
     * firmware version: 3.1.x
 * `v2023.2.x`


### PR DESCRIPTION
Gluon changed the name of the primary branch. Update to make the automatic Gluon base update action work again.

This is only required to apply to the site master branch.