### PR TITLE
build-info: update Gluon to 2024-06-15

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "10728bc8a8ae53f0de8e78ef26497b3aa8826b5a"
+        "commit": "d1ec30ba060174b8d3c0a91beb347343ad404c12"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 10728bc8 to d1ec30ba.

~~~
d1ec30ba Merge pull request #3285 from blocktrron/upstream-main-updates
49be1685 modules: update packages
b9b7e1db modules: update openwrt
3f57bc68 Merge pull request #3283 from blocktrron/pr-main-v2023.2.3-rn
349d0f36 docs readme: Gluon v2023.2.3
f12984e0 docs: add v2023.2.3 release notes
fab66392 treewide: Update main branch name (#3282) ~~~