### PR TITLE
build-info: update Gluon to 2024-06-16

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "d1ec30ba060174b8d3c0a91beb347343ad404c12"
+        "commit": "4050b9e448d863c79490d0137dbfdfe337aecf2e"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from d1ec30ba to 4050b9e4.

Let's do this to generate fixed testing builds for AP3710i.

~~~
4050b9e4 Merge pull request #3287 from blocktrron/upstream-main-updates
d5258e37 modules: update packages
b7390d1e modules: update openwrt
~~~