### PR TITLE
build-info: update Gluon to 2024-06-16

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "068cca0e7a558ff080bec1b4804223bf92db8bdf"
+        "commit": "f0edc3eca7e9d91c53e4b64153cc94e000f9f06d"
     },
     "container": {
         "version": "v2023.2.1"


### PR DESCRIPTION
Update Gluon from 068cca0e to f0edc3ec.

```
f0edc3ec Merge pull request #3284 from blocktrron/v2023.2.x-updates
d06f4cab modules: update packages
8c74d7af modules: update openwrt
ec72498a Merge pull request #3279 from blocktrron/v2023.2.3-release-notes
26118d79 Merge pull request #3278 from blocktrron/v2023.2.x-updates
5b7b636d Merge pull request #3276 from blocktrron/v2023.2.x-update-actions
cc4cc84e github labels: update labeler action to v5
9adddafc docs readme: Gluon v2023.2.3
9df7bdf8 docs: add v2023.2.3 release notes
348ec72d modules: update packages
b7971355 modules: update openwrt
ebb5a2bc github: update build-containr workflow actions
d24a4edc github: bump paths-filter version (#3180)
318f17da github: update upload-artifact action
```