### PR TITLE
build-info: update Gluon to 2024-06-21

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "4050b9e448d863c79490d0137dbfdfe337aecf2e"
+        "commit": "986679a473730bc72b052da52f97f71ab89cce65"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 4050b9e4 to 986679a4.

~~~
986679a4 Merge pull request #3289 from herbetom/main-updates
b8223e91 modules: update packages
4b45ab0f modules: update openwrt
70b7c2f2 build(deps): bump docker/build-push-action from 5.3.0 to 5.4.0 (#3281)
~~~

Signed-off-by: GitHub Actions <info@darmstadt.freifunk.net>