### PR TITLE
build-info: update Gluon to 2024-07-01

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "986679a473730bc72b052da52f97f71ab89cce65"
+        "commit": "b50007d171321e87d6ceca5f983259093d25f1e2"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 986679a4 to b50007d1.

~~~
b50007d1 ramips-mt7621: add support for Xiaomi Mi Router 4a Gigabit Edition v2 (#3293)
9cdd8d51 mesh-vpn-wireguard: fix set incorrect MTU on the wireguard interface (#3258)
fe2273ea build(deps): bump docker/build-push-action from 5.4.0 to 6.2.0 (#3300)
d5d6d0f7 mt76: include fixes for MT7603 / MT7612 (#3261)
d72dabcf Merge pull request #3299 from blocktrron/upstream-main-updates
a3e1288f modules: update packages
f3499bf1 modules: update openwrt
68f6710d private-wifi: rename ifname to wl-wanX 
bdf74d81 ramips-mt76x8: add TP-Link RE200 v4 (#3297)
c61456e3 Merge pull request #3295 from neocturne/debug-default
0f0cbaa5 docs: user/getting_started: fix monospace markup
d09cda05 build: extend GLUON_DEBUG with values 0, 1 and 2
f70526cd Merge pull request #3292 from neocturne/linksys-e4200-v2-fix
fc44ba5a kirkwood-generic: fix device name of Linksys E4200 v2
~~~