### PR TITLE
build-info: update Gluon to 2024-07-08

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "b50007d171321e87d6ceca5f983259093d25f1e2"
+        "commit": "7df8c6284e5a48339aa46d5ccc15706a0d111e10"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from b50007d1 to 7df8c628.

~~~
7df8c628 Merge pull request #3306 from herbetom/main-updates 5e5433da modules: update packages
5ab7964f modules: update openwrt
1af5605c ramips-mt7620: add support for Netgear EX6130 (#3304)
~~~