### PR TITLE
contrib: fix invalid f-string

### DIFF
--- a/contrib/load-attestation.py
+++ b/contrib/load-attestation.py
@@ -67,7 +67,8 @@ def print_attestation(data):
 
     build_commit = build_definition["resolvedDependencies"][0]["digest"]["gitCommit"]
     print(f"  Commit: {build_commit}")
-    print(f"  Run: {run_details["metadata"]["invocationId"]}")
+    invocation_id = run_details["metadata"]["invocationId"]
+    print(f"  Run: {invocation_id}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
F-String was invalid on NixOS due to variable names overlapping with the string double quotes.