### PR TITLE
build-info: update Gluon to 2024-07-18

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "f0edc3eca7e9d91c53e4b64153cc94e000f9f06d"
+        "commit": "05b36ba7608f7ac83373cd4bdfc34ef142e05c76"
     },
     "container": {
         "version": "v2023.2.1"


### PR DESCRIPTION
Update Gluon from f0edc3ec to 05b36ba7.

```
05b36ba7 Merge pull request #3318 from blocktrron/v2023.2.x-updates
9ca21220 modules: update packages
1f8d3acc modules: update openwrt
1a5d69ae Merge pull request #3314 from blocktrron/2302-backports-11072024
c82206c7 ath79-generic: add support for Sophos AP15 (#3126)
f4736922 Merge pull request #3313 from blocktrron/v2023.2.x-updates
a0ff929b gluon-core: fix swconfig detection in ethernet module (#3309)
bdee1140 ramips-mt7620: add support for Netgear EX6130 (#3304)
61ee9227 ramips-mt7621: add support for Xiaomi Mi Router 4a Gigabit Edition v2 (#3293)
fb98bc72 ramips-mt76x8: add TP-Link RE200 v4 (#3297)
8a2fd610 modules: update packages
bfbd49ff modules: update openwrt
```