### PR TITLE
build-info: update Gluon to 2024-07-18

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "7df8c6284e5a48339aa46d5ccc15706a0d111e10"
+        "commit": "d7ed2dfca7a833ac8c23cf4dd86cf92beb918f4b"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 7df8c628 to d7ed2dfc.

~~~
d7ed2dfc Merge pull request #3317 from blocktrron/upstream-main-updates
2b99a849 modules: update packages
b463adb1 modules: update openwrt
5a854853 gluon-web-cellular: add auth option to GUI (#3307)
dc51f3d3 Add documentation for evaluation of mesh-vpn protocols (#3267)
d9cfa194 gluon-core: fix swconfig detection in ethernet module (#3309)
~~~