### PR TITLE
build-meta: support build of deployment tags

### DIFF
--- a/.github/build-meta.sh
+++ b/.github/build-meta.sh
@@ -19,6 +19,9 @@ DEPLOY="0"
 # Don't release by default. Enable for tags.
 CREATE_RELEASE="0"
 
+# This is not the latest release by default.
+LATEST_RELEASE="0"
+
 # Don't link release by default. Enable for testing.
 LINK_RELEASE="0"
 
@@ -39,6 +42,8 @@ TESTING_TAG_RE="^[2-9].[0-9]-[0-9]{8}$"
 CUSTOM_TESTING_TAG_RE="^[2-9].[0-9]-[0-9]{8}"
 # Regex for release firmware tag
 RELEASE_TAG_RE="^[2-9].[0-9].[0-9]$"
+# Regex for release deployment firmware tag
+RELEASE_DEPLOYMENT_TAG_RE="^[2-9].[0-9].[0-9]"
 
 # Get Gluon version information
 if [ -n "$WORKFLOW_DISPATCH_REPOSITORY" ] && [ -n "$WORKFLOW_DISPATCH_REFERENCE" ]; then
@@ -114,9 +119,19 @@ elif [ "$GITHUB_EVENT_NAME" = "push"  ] && [ "$GITHUB_REF_TYPE" = "tag" ]; then
 		MANIFEST_BETA="1"
 		SIGN_MANIFEST="1"
 
+		LATEST_RELEASE="1"
+
 		RELEASE_VERSION="$GITHUB_REF_NAME"
 		BROKEN="0"
 		DEPLOY="1"
+	elif [[ "$GITHUB_REF_NAME" =~ $RELEASE_DEPLOYMENT_TAG_RE ]]; then
+		# Deployment release - autoupdater Branch is stable and enabled
+		AUTOUPDATER_ENABLED="1"
+		AUTOUPDATER_BRANCH="stable"
+
+		RELEASE_VERSION="$GITHUB_REF_NAME"
+		BROKEN="1"
+		DEPLOY="0"
 	else
 		# Unknown release - Disable autoupdater
 		AUTOUPDATER_ENABLED="0"
@@ -174,6 +189,7 @@ echo "sign-manifest=$SIGN_MANIFEST" >> "$BUILD_META_OUTPUT"
 echo "deploy=$DEPLOY" >> "$BUILD_META_OUTPUT"
 echo "link-release=$LINK_RELEASE" >> "$BUILD_META_OUTPUT"
 echo "create-release=$CREATE_RELEASE" >> "$BUILD_META_OUTPUT"
+echo "latest-release=$LATEST_RELEASE" >> "$BUILD_META_OUTPUT"
 echo "target-whitelist=$TARGET_WHITELIST" >> "$BUILD_META_OUTPUT"
 
 # Copy over to GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
         ${{ steps.build-metadata.outputs.sign-manifest }}
       create-release: >-
         ${{ steps.build-metadata.outputs.create-release }}
+      latest-release: >-
+        ${{ steps.build-metadata.outputs.latest-release }}
       deploy: >-
         ${{ steps.build-metadata.outputs.deploy }}
       link-release: >-
@@ -547,5 +549,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body_path: gluon-gha-data/release-notes.md
+          make_latest: ${{ needs.build-meta.outputs.latest-release == '1' }}
           files: |
             gluon-gha-data/release-artifacts/*


### PR DESCRIPTION
When building for a special (automatic deployment) we want to enable the autoupdater.