### PR TITLE
ci: provide means to override build-meta output

### DIFF
--- a/.github/build-meta.sh
+++ b/.github/build-meta.sh
@@ -4,6 +4,22 @@ set -euxo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
 
+OVERRIDES_DIR="$SCRIPT_DIR/overrides/build-meta"
+
+function set_output_value() {
+	local output_file="$1"
+	local name="$2"
+	local value="$3"
+
+	# Check if override is defined
+	if [ -f "$OVERRIDES_DIR/$name" ]; then
+		value="$(cat "$OVERRIDES_DIR/$name")"
+		echo "::notice::Overriding $name with value \"$value\""
+	fi
+
+	echo "$name=$value" >> "$output_file"
+}
+
 # Get Git short hash for repo at $SCRIPT_DIR
 GIT_SHORT_HASH="$(git -C "$SCRIPT_DIR" rev-parse --short HEAD)"
 
@@ -173,24 +189,24 @@ BUILD_META_OUTPUT="$BUILD_META_TMP_DIR/build-meta.txt"
 
 # shellcheck disable=SC2129
 # Not the nicest way to do this, but it works.
-echo "build-meta-output=$BUILD_META_TMP_DIR" >> "$BUILD_META_OUTPUT"
-echo "container-version=$CONTAINER_VERSION" >> "$BUILD_META_OUTPUT"
-echo "gluon-repository=$GLUON_REPOSITORY" >> "$BUILD_META_OUTPUT"
-echo "gluon-commit=$GLUON_COMMIT" >> "$BUILD_META_OUTPUT"
-echo "site-version=$SITE_VERSION" >> "$BUILD_META_OUTPUT"
-echo "release-version=$RELEASE_VERSION" >> "$BUILD_META_OUTPUT"
-echo "autoupdater-enabled=$AUTOUPDATER_ENABLED" >> "$BUILD_META_OUTPUT"
-echo "autoupdater-branch=$AUTOUPDATER_BRANCH" >> "$BUILD_META_OUTPUT"
-echo "broken=$BROKEN" >> "$BUILD_META_OUTPUT"
-echo "manifest-stable=$MANIFEST_STABLE" >> "$BUILD_META_OUTPUT"
-echo "manifest-beta=$MANIFEST_BETA" >> "$BUILD_META_OUTPUT"
-echo "manifest-testing=$MANIFEST_TESTING" >> "$BUILD_META_OUTPUT"
-echo "sign-manifest=$SIGN_MANIFEST" >> "$BUILD_META_OUTPUT"
-echo "deploy=$DEPLOY" >> "$BUILD_META_OUTPUT"
-echo "link-release=$LINK_RELEASE" >> "$BUILD_META_OUTPUT"
-echo "create-release=$CREATE_RELEASE" >> "$BUILD_META_OUTPUT"
-echo "latest-release=$LATEST_RELEASE" >> "$BUILD_META_OUTPUT"
-echo "target-whitelist=$TARGET_WHITELIST" >> "$BUILD_META_OUTPUT"
+set_output_value "$BUILD_META_OUTPUT" "build-meta-output" "$BUILD_META_TMP_DIR"
+set_output_value "$BUILD_META_OUTPUT" "container-version" "$CONTAINER_VERSION"
+set_output_value "$BUILD_META_OUTPUT" "gluon-repository" "$GLUON_REPOSITORY"
+set_output_value "$BUILD_META_OUTPUT" "gluon-commit" "$GLUON_COMMIT"
+set_output_value "$BUILD_META_OUTPUT" "site-version" "$SITE_VERSION"
+set_output_value "$BUILD_META_OUTPUT" "release-version" "$RELEASE_VERSION"
+set_output_value "$BUILD_META_OUTPUT" "autoupdater-enabled" "$AUTOUPDATER_ENABLED"
+set_output_value "$BUILD_META_OUTPUT" "autoupdater-branch" "$AUTOUPDATER_BRANCH"
+set_output_value "$BUILD_META_OUTPUT" "broken" "$BROKEN"
+set_output_value "$BUILD_META_OUTPUT" "manifest-stable" "$MANIFEST_STABLE"
+set_output_value "$BUILD_META_OUTPUT" "manifest-beta" "$MANIFEST_BETA"
+set_output_value "$BUILD_META_OUTPUT" "manifest-testing" "$MANIFEST_TESTING"
+set_output_value "$BUILD_META_OUTPUT" "sign-manifest" "$SIGN_MANIFEST"
+set_output_value "$BUILD_META_OUTPUT" "deploy" "$DEPLOY"
+set_output_value "$BUILD_META_OUTPUT" "link-release" "$LINK_RELEASE"
+set_output_value "$BUILD_META_OUTPUT" "create-release" "$CREATE_RELEASE"
+set_output_value "$BUILD_META_OUTPUT" "latest-release" "$LATEST_RELEASE"
+set_output_value "$BUILD_META_OUTPUT" "target-whitelist" "$TARGET_WHITELIST"
 
 # Copy over to GITHUB_OUTPUT
 cat "$BUILD_META_OUTPUT" >> "$GITHUB_OUTPUT"

--- a/.github/validate-overrides.sh
+++ b/.github/validate-overrides.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Validate no files in .github/overrides/build-meta contain newlines
+
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+
+OVERRIDES_DIR="$SCRIPT_DIR/overrides/build-meta"
+
+FILES_WITH_TWO_LINES=""
+
+# Find all files which contain at lest two lines
+while IFS= read -r -d '' file
+do
+	if [ "$(wc -l < "$file")" -gt 1 ]; then
+		FILES_WITH_TWO_LINES="$FILES_WITH_TWO_LINES $file"
+	fi
+done <   <(find "$OVERRIDES_DIR" -type f -print0)
+
+# Check for newlines in overrides
+if [ -n "$FILES_WITH_TWO_LINES" ]; then
+	echo "The following files contain newlines:"
+	echo "$FILES_WITH_TWO_LINES"
+	exit 1
+fi
+
+exit 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,18 @@ on:
         required: false
 
 jobs:
+  validate-overrides:
+    runs-on: ubuntu-22.04
+    name: Validate CI overrides
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Validate overrides
+        run: |
+          bash .github/validate-overrides.sh
+
   build-meta:
+    needs: validate-overrides
     outputs:
       container-version: >-
         ${{ steps.build-metadata.outputs.container-version }}


### PR DESCRIPTION
Provide a way to override properties determined in the build-meta step.

This allows to alter specific settings for a build if a special build for e.g. a automatic installation image is desired.