### PR TITLE
ci: print warning when signing should happen in fork

### DIFF
--- a/.github/build-meta.sh
+++ b/.github/build-meta.sh
@@ -172,6 +172,13 @@ if [ "$GITHUB_REPOSITORY" != "$UPSTREAM_REPO_NAME" ] && [ "$SIGN_MANIFEST" != "0
 	echo "::warning::Skip manifest signature due to action running in fork."
 fi
 
+# We should neither deploy in a fork, as the workflow is hard-coding out firmware-server
+if [ "$GITHUB_REPOSITORY" != "$UPSTREAM_REPO_NAME" ] && [ "$DEPLOY" != "0" ]; then
+	DEPLOY="0"
+
+	echo "::warning::Skip deployment due to action running in fork."
+fi
+
 # Determine Version to use
 RELEASE_VERSION="${RELEASE_VERSION:-$DEFAULT_RELEASE_VERSION}"
 

--- a/.github/build-meta.sh
+++ b/.github/build-meta.sh
@@ -3,6 +3,7 @@
 set -euxo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
+UPSTREAM_REPO_NAME="freifunk-darmstadt/site-ffda"
 
 # Get Git short hash for repo at $SCRIPT_DIR
 GIT_SHORT_HASH="$(git -C "$SCRIPT_DIR" rev-parse --short HEAD)"
@@ -161,6 +162,14 @@ if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
 	DEPLOY="0"
 	CREATE_RELEASE="0"
 	SIGN_MANIFEST="0"
+fi
+
+# Signing should only happen when pushed to the upstream repository.
+# Skip this step for the pipeline to succeed but inform the user.
+if [ "$GITHUB_REPOSITORY" != "$UPSTREAM_REPO_NAME" ] && [ "$SIGN_MANIFEST" != "0" ]; then
+	SIGN_MANIFEST="0"
+
+	echo "::warning::Skip manifest signature due to action running in fork."
 fi
 
 # Determine Version to use


### PR DESCRIPTION
Currently the CI pipeline fails when the image is built in a fork with a tag that matches a release that should be signed.

This is due to the signing keys missing in the fork.

This might break cases where a sign in a fork is desired, however we do not support this and probably also don't want this.

If other people desire to use the script, they can exchange UPSTREAM_REPO_NAME with their own GitHub repo name.

Inform the user if this happens with a warning message.