### PR TITLE
contrib: create annotated tags

### DIFF
--- a/contrib/create-release.sh
+++ b/contrib/create-release.sh
@@ -53,7 +53,7 @@ check_input_y "Proceed to tag firmware release for '$RELEASE_NAME' (Tag: '$TAG_N
 
 echo "Proceeding to tag firmware release with $RELEASE_NAME"
 
-git tag "$TAG_NAME"
+git tag -a -m "$TAG_NAME" "$TAG_NAME"
 
 echo "Tag was created"
 echo "Push with 'git push origin $TAG_NAME'"


### PR DESCRIPTION
This makes the tag-based refs work again.

Closes #11