### PR TITLE
[v2023.2.x] build-info: update Gluon to 2024-10-03

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "05b36ba7608f7ac83373cd4bdfc34ef142e05c76"
+        "commit": "d2a9cc369a32dd1c1b5ffb9ac7a452d78457043d"
     },
     "container": {
         "version": "v2023.2.1"


### PR DESCRIPTION
Update Gluon from 05b36ba7 to d2a9cc36.

```
d2a9cc36 Merge pull request #3345 from herbetom/v2023.2.4-release-notes
40f612a5 Merge pull request #3343 from blocktrron/v2023.2.x-updates
934d2c9c docs readme: Gluon v2023.2.4
3f6b43db docs: add v2023.2.4 release notes
535f4283 modules: update packages
ffe9cf85 modules: update openwrt
8d04b5e4 Merge pull request #3341 from herbetom/v2023.2.x-updates
fd51363c modules: update routing
918025b6 modules: update packages
5caa67dd modules: update openwrt
bd5c28e1 docs: update python3-distutils package name (#3326)
1d8bce0a Merge pull request #3325 from blocktrron/v2023.2.x-updates
65322698 modules: update routing
68866210 modules: update packages
87d81f01 modules: update openwrt
```

Signed-off-by: GitHub Actions <info@darmstadt.freifunk.net>
