### PR TITLE
build-info: update Gluon to 2024-10-04

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "52a15803d2004a2c7439bfde3e3289d384dc9112"
+        "commit": "61ec97e84c617a35cb28ac9613fadc1632b3c64b"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 52a15803 to 61ec97e8.

~~~
61ec97e8 Merge pull request #3348 from blocktrron/v2023.2.4-main
8a2baf86 docs readme: Gluon v2023.2.4
91d82e17 docs: add v2023.2.4 release notes
7da85f60 Merge pull request #3346 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.9.0
5c5ede37 build(deps): bump docker/build-push-action from 6.7.0 to 6.9.0
c0cbcde8 Merge pull request #3342 from blocktrron/upstream-main-updates
fbe05c91 modules: update packages
e0476386 modules: update openwrt
603a08af Merge pull request #3340 from herbetom/main-updates
54c51d4c modules: update packages
f08b712f modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@darmstadt.freifunk.net>