### PR TITLE
build-info: update Gluon to 2024-11-05

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "61ec97e84c617a35cb28ac9613fadc1632b3c64b"
+        "commit": "7cc3ebddd7ea32ae14167389535cbc7d1df95d8e"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 61ec97e8 to 7cc3ebdd.

~~~
7cc3ebdd ipq806x-generic: add Ubiquiti UniFi AC HD (#3361)
d3813362 generic: add gluon grub title (#3366)
a836ae7a ramips-mt7621: add Ubiquiti UniFi nanoHD (#3362)
873e5f7b docs readme: update hackint webchat URL (#3360)
19cb769b Merge pull request #3353 from neocturne/kirkwood-updates
5ed07dc7 kirkwood-generic: add Linksys EA4500
b03393b2 kirkwood-generic: update reason for BROKEN
31933ff1 Merge pull request #3351 from neocturne/main-updates
f0f50aff modules: update packages
f0d5a821 modules: update openwrt
e6bba9fc Revert "tools flex: disable parallel build (#3169)" (#3350)
145ebf06 Merge pull request #3327 from freifunk-gluon/dependabot/pip/docs/sphinx-8.0.2
ebdd3941 docs: conf.py: update deprecated source_suffix configuration
fa5fbdcb docs: requirements.txt: update to Sphinx 8.0.2 and sphinx-rtd-theme 3.0.0
~~~

Signed-off-by: GitHub Actions <info@darmstadt.freifunk.net>
