### PR TITLE
build-info: update Gluon to 2024-12-09

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "f3cae19c6b72a99793f2dcb087c72aa2d756d355"
+        "commit": "f18a350aebb670eaf93d17b41e030db54900b771"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from f3cae19c to f18a350a.

~~~
f18a350a Merge pull request #3370 from freifunk-gluon/openwrt-24.10
77a83ce1 generic: enable kernel namespace support
4bbe5550 generic: fix ramips-mt76x8 compile
b7481fd0 modules: switch to OpenWrt 24.10
3688bf2e scripts: remove temporary output directory
224d0aa7 ramips-mt7621: remove Edgerouter X
35b70fce mediatek-mt7622: remove Xiaomi Redmi AX6S
702211ac routing: remove noflood
b1cdcc87 docker: add missing dependencies
~~~