### PR TITLE
build-info: update Gluon to 2024-12-10

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "f18a350aebb670eaf93d17b41e030db54900b771"
+        "commit": "608a665844d938c6a3b2029e04c271b2784b1b9d"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from f18a350a to 608a6658.

~~~
608a6658 Merge pull request #3382 from freifunk-gluon/dependabot/github_actions/docker/metadata-action-5.6.1
80a16ba0 Merge pull request #3383 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.10.0
92845384 Merge pull request #3381 from freifunk-gluon/dependabot/pip/docs/sphinx-rtd-theme-3.0.2
adbb283e Merge pull request #3380 from grische/add-nanopi-r3s-support
f18b1d9f Merge pull request #3372 from T-X/pr-openwrt-24.10-bridge-wakeupcall
b4b3cb29 Merge pull request #3371 from T-X/pr-openwrt-24.10-batman-adv-noflood
aa39a94e add support for NanoPi R3S
2b129f68 kernel: bridge: readding MLD wakeup call feature
bfff4233 Revert "routing: remove noflood"
7c0b77b3 build(deps): bump docker/build-push-action from 6.9.0 to 6.10.0
43861fa6 build(deps): bump docker/metadata-action from 5.5.1 to 5.6.1
b31f045d build(deps): bump sphinx-rtd-theme from 3.0.0 to 3.0.2 in /docs
~~~

Signed-off-by: GitHub Actions <info@darmstadt.freifunk.net>