### PR TITLE
build-info: update Gluon to 2025-01-08

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "608a665844d938c6a3b2029e04c271b2784b1b9d"
+        "commit": "a475b1919cead4c7d476a321303e6610ad879157"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 608a6658 to a475b191.

~~~
a475b191 gluon-private-wifi: rename psk3 to sae
4c7aef6e Merge pull request #3411 from blocktrron/upstream-main-updates
912527ab wifi-scripts: allow per-IF mesh basic rate selection
fb08eabb gluon-core: set basic-rate for mesh interface
06e421ed net: mac80211: always pretend 1 Mbit/s as mesh basic rate
d6e74f00 net: mac80211: override incompatible basic-rates for mesh
ebc4a606 generic: rename SECCOMP config option
f168aca9 modules: update packages
fbe070c4 modules: update openwrt
e5675adc docs: add AP3915i to supported_devices (#3413)
c31c7d75 Merge pull request #3405 from ffac/allow_fb7530_dsl
828ac800 Merge pull request #3396 from ffac/ap3915i
d87fadb7 ipq40xx-generic: add extreme-networks-ws-ap3915i
e1523af5 Merge pull request #3401 from ffac/update-openwrt-main-1734975929
6b80b580 mediatek-filogic: add Cudy AP3000 Outdoor v1 (#3384)
b5ba291b readd moved xrx200_legacy target
b110494f remove devices which were moved to lantiq-xrx200_legacy
b720d4d0 patches: make refresh-patches
d66cfc0c modules: update packages
9271070c modules: update openwrt
1757fff8 ipq40xx-generic: add working VDSL config for FB7530
4f6de05a Merge pull request #3403 from ffac/silence_airtime_link_metric_get
e594ce2e mac80211: silence warning for missing rate information
717bf99c Merge pull request #3400 from RolandoMagico/D-Link_M30
1e50f2e4 mediatek-filogic: Add support for D-Link AQUILA PRO AI M30 A1
fc25b494 Merge pull request #3394 from grische/drop-python3-distutils
246489be Merge pull request #3399 from ffac/update-openwrt-main-1734601207
f2aeb462 ath79: Add support for Sophos AP15C (#3385)
def60f86 modules: update routing
8998470d modules: update packages
c5700b64 modules: update openwrt
3af76af4 Merge pull request #3387 from herbetom/main-updates
3654f83a libgluonutil: add missing libgen import (#3395)
51719c69 Dockerfile: drop dependency on python3-distutils
879e4501 modules: update routing
36d907fe modules: update packages
a625ae4f modules: update openwrt
b180fc28 Merge pull request #3363 from freifunk-gluon/dependabot/pip/docs/sphinx-8.1.3
d16fe2ae docs: user/supported_devices: remove unreferenced footnote
9dd90850 build(deps): bump sphinx from 8.0.2 to 8.1.3 in /docs ~~~