### PR TITLE
build-info: update Gluon to 2025-01-10

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "a475b1919cead4c7d476a321303e6610ad879157"
+        "commit": "24a5fd4dc1f9131aa7e8d2dac54ddc75ec8c1b1d"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from a475b191 to 24a5fd4d.

~~~
24a5fd4d Merge pull request #3421 from ffac/update-openwrt-main
56ad0ae9 Merge pull request #3422 from s-2/m30
b3130ff4 docs: move D-Link M30, M60 to mediatek-filogic
c99f9c04 modules: update packages
e9098728 modules: update openwrt
791e39f4 Merge pull request #3407 from RolandoMagico/M60
0b23f899 mac80211: silence mesh rate mismatch warning (#3416)
9c914db0 mediatek-filogic: Add support for D-Link AQUILA PRO AI M60 A1
~~~

Signed-off-by: GitHub Actions <info@darmstadt.freifunk.net>