### PR TITLE
build-info: update Gluon to 2025-01-11

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "24a5fd4dc1f9131aa7e8d2dac54ddc75ec8c1b1d"
+        "commit": "ab1c311845ba72484c88294fe2735fbc028b9ba5"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 24a5fd4d to ab1c3118.

~~~
ab1c3118 net: mac80211: force backwards compatible basic rates (#3419)
~~~

Signed-off-by: GitHub Actions <info@darmstadt.freifunk.net>
