### PR TITLE
build-info: update Gluon to 2025-01-27

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "ab1c311845ba72484c88294fe2735fbc028b9ba5"
+        "commit": "cd074cc93d2fdaacbf91c90ca25c6a28f4d1b575"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from ab1c3118 to cd074cc9.

~~~
cd074cc9 Merge pull request #3434 from ffac/update-openwrt-main
7e619101 Merge pull request #3432 from ffac/tplink_ax23
3035005d modules: update packages
02cf7d43 modules: update openwrt
5b4e1091 ramips-mt7621: add tp-link ax23
ff58f65a ramips-mt7621: add support netgear eax12 (#3433)
ad321f50 Merge pull request #3429 from ffac/update-openwrt-main
a4c78821 modules: update packages
368ee823 modules: update openwrt
3c04d32d Merge pull request #3428 from blocktrron/upstream-main-updates
8f853668 armsr: change image name
2cf299d8 modules: update routing
e2b5bca6 modules: update packages
8137470e modules: update openwrt
~~~