### PR TITLE
build-info: update Gluon to 2025-03-09

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "cd074cc93d2fdaacbf91c90ca25c6a28f4d1b575"
+        "commit": "cf9f0f92d8f74f5564732787e1786cf8c9908d0f"
     },
     "container": {
         "version": "main"

--- a/.github/free-runner-space.sh
+++ b/.github/free-runner-space.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# For a List of pre-installed packages on the runner image see
+# https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images
+
+echo "Disk space before cleanup"
+df -h
+
+# Remove packages not required to run the Gluon build CI
+sudo apt-get -y remove \
+	dotnet-* \
+	firefox \
+	google-chrome-stable \
+	kubectl \
+	microsoft-edge-stable \
+	temurin-*-jdk
+
+# Remove Android SDK tools
+sudo rm -rf /usr/local/lib/android
+
+echo "Disk space after cleanup"
+df -h

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,6 +240,9 @@ jobs:
       - name: Print meminfo
         run: cat /proc/meminfo
 
+      - name: Remove non-required software
+        run: bash .github/free-runner-space.sh
+
       - name: Download prepared OpenWrt
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Update Gluon from cd074cc9 to cf9f0f92.

~~~
cf9f0f92 Merge pull request #3436 from blocktrron/mt7915-20250113-restart
55d654ff mediatek-filogic: add support for OpenWRT One (#3446)
1feed04d actions: remove non-required packages (#3448)
37886a4c Merge pull request #3447 from blocktrron/upstream-main-updates
2f9461df openwrt: remove mt76 patch
937d25be build: use host LLVM toolchain
8d50f440 Merge pull request #3444 from freifunk-gluon/dependabot/github_actions/korthout/backport-action-3.2.0
ace6ebcd Merge pull request #3443 from freifunk-gluon/dependabot/github_actions/docker/metadata-action-5.7.0
dcf67010 Merge pull request #3442 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.15.0
f42266d3 contrib docker: sort package-list
c98454eb modules: update routing
e3120771 modules: update packages
ad1bea9c modules: update openwrt
5f77bba0 build(deps): bump korthout/backport-action from 3.1.0 to 3.2.0
7a98065d build(deps): bump docker/metadata-action from 5.6.1 to 5.7.0
a48d30d8 build(deps): bump docker/build-push-action from 6.13.0 to 6.15.0
49079cfb Merge pull request #3427 from ffac/rssi_for_5ghz
56f9f391 Merge pull request #3437 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.13.0
94a7eb1b mt76: import MT7915 recovery fixes
ae807135 build(deps): bump docker/build-push-action from 6.10.0 to 6.13.0
4e2188a7 gluon-core: set 5GHz rssi leds to mesh1 connectivity
~~~

Signed-off-by: GitHub Actions <info@darmstadt.freifunk.net>