### PR TITLE
build-info: update Gluon to 2025-03-19

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "cf9f0f92d8f74f5564732787e1786cf8c9908d0f"
+        "commit": "28f2ee9a923bd9253ca2663d551e585590da2561"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from cf9f0f92 to 28f2ee9a.

~~~
28f2ee9a Merge pull request #3445 from freifunk-gluon/dependabot/pip/docs/sphinx-8.2.1
6ca4d7b9 docs: bump sphinx from 8.1.3 to 8.2.3
44a9abd0 actions: build docs on Ubuntu 24.04
91264654 Merge pull request #3406 from ffac/remove_migrations
d7225ba7 core: remove old migrations
5e1849e2 Merge pull request #3355 from blocktrron/poe-passthrough-active-low
ed8de418 Merge pull request #3424 from herbetom/fixup-toollist-getting_started
d91f3f34 docs: user/getting_started: add dependencies
e2de86ce Merge pull request #3449 from herbetom/main-refresh-patches
d29174ba patches: refresh-patches
b0671dd7 gluon-web-network: support handling of active-low PoE passthrough
~~~

Signed-off-by: GitHub Actions <info@darmstadt.freifunk.net>