### PR TITLE
build-info: update Gluon to 2025-04-28

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "08ce23fc551fd8ed36b265bbbd484492d3236684"
+        "commit": "4627d80d69872a93b65ef0c94753d31b6831a431"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 08ce23fc to 4627d80d.

~~~
4627d80d Merge pull request #3494 from herbetom/main-updates
0212815e modules: update routing
181de471 modules: update packages
e22840e2 modules: update openwrt
4be93f94 Merge pull request #3493 from blocktrron/tr1200
25c0dacc Merge pull request #3492 from blocktrron/pr-mt2500
8720ce43 ath79-nand:  add support for GL.iNet E750 (#3476)
08ea643f ramips-mt76x8: add support for Cudy TR1200 v1
6d2e0183 mediatek-filogic: add GL.iNet GL-MT2500
~~~

Signed-off-by: GitHub Actions <info@darmstadt.freifunk.net>