### PR TITLE
build-meta: fix dash replacement in release version

### DIFF
--- a/.github/build-meta.sh
+++ b/.github/build-meta.sh
@@ -146,7 +146,8 @@ elif [ "$GITHUB_EVENT_NAME" = "push"  ] && [ "$GITHUB_REF_TYPE" = "tag" ]; then
 		AUTOUPDATER_ENABLED="1"
 		AUTOUPDATER_BRANCH="stable"
 
-		RELEASE_VERSION="$GITHUB_REF_NAME"
+		# shellcheck disable=SC2001
+		RELEASE_VERSION="$(echo "$GITHUB_REF_NAME" | sed 's/-/~/')"
 		BROKEN="1"
 		DEPLOY="0"
 	else


### PR DESCRIPTION
Replace the first occurence of a dash character in the RELEASE_VERSION.

This is required, as deployment releases should use the version number of the next stable release, not the current one.

The dash qualifies them as pre-releases for the autoupdater, updating to the stable version once released.