### PR TITLE
[v2023.2.5] build-info: update Gluon to v2023.2.5

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "0be35204a650fe5879675942e0b687e5a959068d"
+        "commit": "031a835e4f6658dc6f720ef55635baf4841a7cb6"
     },
     "container": {
         "version": "v2023.2.1"


### PR DESCRIPTION
Update Gluon from 0be35204 to 031a835e.

```
031a835e Merge pull request #3515 from blocktrron/pr-v2023.2.5-rn
1ec4a686 docs readme: Gluon v2023.2.5
f6541b26 docs: add Gluon v2023.2.5 release notes
a52d3519 Merge pull request #3513 from blocktrron/v2023.2.x-updates
05d2b674 modules: update packages
c3c28740 modules: update openwrt
ea80921a Merge pull request #3509 from blocktrron/pr-ex400-2023.2
c680ce29 ramips-mt7621: add support for Genexis Pulse EX400
8d629bb3 ramips-mt7621: backport Genexis Pulse EX400 to OpenWrt 23.05
285e1814 gluon-setup-mode: execute bootcount initscript in setup-mode
```