### PR TITLE
build-info: update Gluon to 2025-06-24

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "9794e83be891b0f24d8b19befb3f81bf1e8494ff"
+        "commit": "e80777b86761419647cd39ced76639af1920494e"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 9794e83b to e80777b8.

~~~
e80777b8 Merge pull request #3527 from dg0tm/main
44073921 ramips-mt7621: add back Edgerouter X" (#3533)
c8b1dad3 Merge pull request #3529 from freifunk-gluon/main-updates
000b6e51 modules: update routing
acd7cf9d modules: update packages
bdf0720e modules: update openwrt
d7619c60 gluon-state-ntpd-check: Add package (#3528)
dbf3e4d6 gluon-mesh-layer3-common: get rid of substitution count returned by gsub on prefix
~~~

Signed-off-by: GitHub Actions <info@darmstadt.freifunk.net>