### PR TITLE
build-info: update Gluon to 2025-09-16

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "9143b02374322d304386f87b1c67e81c345c49e6"
+        "commit": "4902bbd2ea475224075d51240929fb6d649de954"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 9143b023 to 4902bbd2.

~~~
4902bbd2 Merge pull request #3582 from ffac/update-openwrt-base 38a38996 modules: update routing
abfd4a96 modules: update packages
dd55d50a modules: update openwrt
e740dc8c ramips-mt76x8: add support for TP-Link Archer C50 v6 (#3568)
79910654 Merge pull request #3554 from freifunk-gluon/feat/statuspage-pubkey
21e37349 Merge pull request #3561 from freifunk-gluon/feat/add_xiaomi_ax3600
3b029f92 status-page: Emit VPN public key if enabled
73129414 mesh-vpn-core: Provide get_enabled_public_key()
cb20f286 qualcommax-ipq807x: Add Xiaomi AX3600
38b478c3 Merge pull request #3578 from freifunk-gluon/fix/remove-wireguard-pubkey-privacy
3b2b071f Merge pull request #3581 from freifunk-gluon/docs/gluon-state-check
f34cf48f gluon-client-bridge: provide owe with its correct wifi mac (#3579)
a41b604c gluon-state-check: Provide documentation
cce9ccdb Merge pull request #3577 from herbetom/main-updates
076c819a modules: update packages
1bd1eb10 modules: update openwrt
15681ac6 Merge pull request #3570 from freifunk-gluon/feat/configurable-uradvd-parameters-updates
f549310f gluon-radvd: Allow lifetime configuration in site
2a9dfcb7 mesh-vpn: Remove `pubkey_privacy` setting for WireGuard
09893668 Merge pull request #3573 from freifunk-gluon/dependabot/github_actions/korthout/backport-action-3.3.0
06fd1bb1 Merge pull request #3575 from freifunk-gluon/dependabot/github_actions/actions/checkout-5
b8f932fe Merge pull request #3574 from freifunk-gluon/dependabot/github_actions/docker/metadata-action-5.8.0 
f5f9d91f Merge pull request #3572 from freifunk-gluon/dependabot/github_actions/docker/login-action-3.5.0
750faacb build(deps): bump actions/checkout from 4 to 5
3a26a65a build(deps): bump docker/metadata-action from 5.7.0 to 5.8.0
912826d3 build(deps): bump korthout/backport-action from 3.2.1 to 3.3.0
a0b71e60 build(deps): bump docker/login-action from 3.4.0 to 3.5.0
dcc57872 Merge pull request #3571 from freifunk-gluon/fix/mesh-layer3-common-new-site-library
2c7f0e84 mesh-layer3-common: Omit redundant check
9763474c mesh-layer3-common: fix radvd start with dns.servers, but without next_node.ip config
76f2a3db Merge pull request #3569 from freifunk-gluon/main-updates
8ec28057 gluon-mesh-batman-adv: fix has_default_gw4 (#3567)
ee32cd3c modules: update packages
18c2ce54 modules: update openwrt
2c5a088d Merge pull request #3565 from herbetom/fix-update-modules
60ef31df scripts: update-modules: always request git remote branch head
e00940ef mvebu-cortexa53: add support for GL.iNet GL-MV1000 (#3562)
125090b9 Merge pull request #3566 from herbetom/main-updates
051d30d6 modules: update routing
0a92cd44 modules: update packages
dcf5ff58 modules: update openwrt
6d3ceffc Merge pull request #3556 from ffac/fix_default_gw4_for_parker
bd1d2b18 gluon-mesh-batman-adv: improve has_default_gw4 for parker
240a3b3c Merge pull request #3559 from FreifunkChemnitz/ax3000t
018f945b mediatek: filogic: add support for Xiaomi AX3000T
033a9ebe Merge pull request #3553 from FreifunkChemnitz/cpe710v2
6992ceb3 ath79-generic: add support for TP-Link CPE710-v2 ~~~