### PR TITLE
site: add pilz signing key

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -149,6 +149,7 @@
 					'bead63b9e44f5243e3030a37fdc0d1cd3efce65234c7bedfcff6ae6452d42e79', -- tomh
 					'0ebac3d341673dbeb8b6d2499811ce7851516aae851d71067a3e16488dee44c7', -- skorpy
 					'5b8ce650fc50d845975567bd5418fcd5c091528e48e95cf0e2f0266ed509e013', -- alex
+					'3c4643959cac981de03d0fdddbc879bd501645672d99c903797f1e25a538ffda', -- pilz
 				},
 			},
 			beta = {
@@ -165,6 +166,7 @@
 					'bead63b9e44f5243e3030a37fdc0d1cd3efce65234c7bedfcff6ae6452d42e79', -- tomh
 					'0ebac3d341673dbeb8b6d2499811ce7851516aae851d71067a3e16488dee44c7', -- skorpy
 					'5b8ce650fc50d845975567bd5418fcd5c091528e48e95cf0e2f0266ed509e013', -- alex
+					'3c4643959cac981de03d0fdddbc879bd501645672d99c903797f1e25a538ffda', -- pilz
 				},
 			},
 			testing = {


### PR DESCRIPTION
Wie besprochen hier die PR für den signing key, hab mal zum testen 3.0.8 signiert:
```
Download manifest archvie from https://github.com/freifunk-darmstadt/site-ffda/releases/download/3.0.8/manifest.tar.xz
Extracting manifest archive to /tmp/nix-shell-2455776-0/tmp.5Yw7kTNAUU
Manifest /tmp/nix-shell-2455776-0/tmp.5Yw7kTNAUU/beta.manifest is signed with CI key
Signature: 40ddbad384c569dde5aac743ca797e8972d1cc3618ea6dd9dee98292686356039ca46dc0dc6598c51da86192dca93264e339b9c5ee47ac076dfecfe9c8a96903
-- Signature for beta --
779a777baf2415952f01ec0ebc76c3a1a63f6f560da657b136d0a31b591e1a03fad1de1c5dc9a34769707afcc7aca7b40b55d3d7dfa32aa6f115e27cd6c3ca02
Manifest /tmp/nix-shell-2455776-0/tmp.5Yw7kTNAUU/stable.manifest is signed with CI key
Signature: 9f0fb461f4de3a89ef27d219186cb86c96b52cf7a84f1bfa3113aee3cf42e20a321b5a61f97cc3d141bc89d62807ae99c9f49504d0ed8c1c10c75e5d1380e907
-- Signature for stable --
137e05dff43213c7ff69ee0f0b4a17a5961289a21f6643bf7cfac2595d2c1207e72543e2e99537537351f74c869a9794a1f62c7fcb1f1d546ace6dec8e384403

````