### PR TITLE
build-info: update Gluon to 2025-11-10

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "4902bbd2ea475224075d51240929fb6d649de954"
+        "commit": "8abad80deb907dd2900b8fddad5b4d49f687c1d0"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 4902bbd2 to 8abad80d.

~~~
8abad80d Merge pull request #3609 from herbetom/main-updates
7f7bba6c modules: update packages
ab8dfbfd modules: update openwrt
423258a7 Merge pull request #3607 from achterin/feature/netgear_srr60_srs60
cd07df9d Merge pull request #3605 from FreifunkChemnitz/whw03v1
50da04f8 Merge pull request #3598 from ffac/fix_mt7622_renaming
f64e7e7f ipq40xx-generic: add NETGEAR SRR60/SRS60
e8fb6abd ipq40xx-generic: add support for linksys-whw03v1
b74fed5f Merge pull request #3606 from FreifunkChemnitz/mr8300
d04ea647 ipq40xx-generic: add linksys-mr8300
6ad79c9d Merge pull request #3603 from freifunk-gluon/dependabot/github_actions/korthout/backport-action-3.4.1 
6e878ea0 Merge pull request #3604 from freifunk-gluon/dependabot/github_actions/actions/upload-artifact-5
f5ba5863 build(deps): bump actions/upload-artifact from 4 to 5
6092c827 build(deps): bump korthout/backport-action from 3.3.0 to 3.4.1
99aeac40 Merge pull request #3418 from ffac/add_linksys_whw03_v2
484e265b patches: base-files: disable wiphy renaming
72c4c1a8 ipq40xx-generic: add support for linksys-whw03v2
8f28f725 Merge pull request #3563 from ffac/refactor-wireless-triband
462e6a4d gluon-core: allow configuration of additional wireless settings using gluon_preserve
adc0867c gluon-core: set channel to auto if mesh is not possible
d7f2f1de gluon-core: implement detection of client_only_radio
442a6801 Merge pull request #3595 from achterin/feature/linksys_whw01_v1-updates
d6bf8a75 ipq40xx-generic: add Linksys VLP01 alias
ad7638b9 ipq40xx-generic: add Linksys WHW01
93968ca7 Merge pull request #3597 from freifunk-gluon/main-updates
8cfa65a9 modules: update packages
fe5f1594 modules: update openwrt
a34a3c7f Merge pull request #3596 from freifunk-gluon/main-issue-3425
7baa3c0b ath79-generic: additional reason for BROKEN device Archer C58
fcabea4f Merge pull request #3594 from freifunk-gluon/main-updates
418b4ffa modules: update packages
c809a926 modules: update openwrt
e742f024 gluon-web-wifi-config: adjust form for gluon roles
1ed6fba9 gluon-web-private-wifi: update to role based wireless section
b98109db gluon-private-wifi: add uci wireless config to gluon-private-wifi
58cd14b5 gluon-client-bridge: do not create wireless config if client role is disabled
97747da2 gluon-core: remove delete_ibss function
17f59562 gluon-core: add hop_penalty support for mesh interfaces and fix preserve_channels
8e9bc5c6 gluon-core: create wireless config from gluon wireless roles section
d654fd2a Merge pull request #3590 from freifunk-gluon/main-updates
25dcbc4a modules: update gluon
a3e76518 Merge pull request #2995 from T-X/pr-gluon-mesh-batman-adv-brmldproxy
96c7ba28 gluon-core: add initialization script of gluon wireless roles
80ac3327 ath79-generic: (re)add support for Buffalo WZR-HP-G450H / WZR-450HP (#3588)
124b0acd Merge pull request #3587 from herbetom/main-updates
4a029fa8 gluon-core: clean up band counting
e0d1d85c gluon-core: rename device_uses_11a to device_uses_band
ff028f1a modules: update routing
7dab1cfa modules: update packages
b78b3e18 modules: update openwrt
a38c4a2f Merge pull request #3584 from freifunk-gluon/dependabot/github_actions/actions/labeler-6
31fe8b82 Merge pull request #3585 from freifunk-gluon/dependabot/github_actions/docker/login-action-3.6.0
e0f77127 build(deps): bump docker/login-action from 3.5.0 to 3.6.0
2de3cb86 build(deps): bump actions/labeler from 5 to 6
f6ac72b8 gluon-mesh-batman-adv-brmldproxy: enable proxied querier with mc routers
80f9d191 gluon-mesh-batman-adv-brmldproxy: don't filter incoming MLD Reports
8ec599ca gluon-mesh-batman-adv-brmldproxy: avoid MLD report broadcasts
c6ee0f24 gluon-mesh-batman-adv-brmldproxy: add package
~~~