### PR TITLE
github: add ability to patch Gluon

### DIFF
--- a/.github/apply-site-patches.sh
+++ b/.github/apply-site-patches.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+REPO_PATH="$1"
+PATCHES_PATH="$(pwd)/$2"
+
+for patch in "$PATCHES_PATH"/*.patch; do
+	[ -e "$patch" ] || continue
+	echo "Applying patch $patch"
+	git -C "$REPO_PATH" am "$patch"
+done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,16 @@ jobs:
           ref: ${{ needs.build-meta.outputs.gluon-commit }}
           path: 'gluon-gha-data/gluon'
 
+      - name: Set Git config
+        run: |
+          git config --global user.name "Site CI"
+          git config --global user.email "site-ci@darmstadt.freifunk.net"
+
+      - name: Apply Site-Patches
+        run: >
+          bash .github/apply-site-patches.sh
+          gluon-gha-data/gluon patches/gluon
+
       - name: Determine Cache-Key
         id: cache-key
         run: >
@@ -225,6 +235,16 @@ jobs:
           path: 'gluon-gha-data/gluon'
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Set Git config
+        run: |
+          git config --global user.name "Site CI"
+          git config --global user.email "site-ci@darmstadt.freifunk.net"
+
+      - name: Apply Site-Patches
+        run: >
+          bash .github/apply-site-patches.sh
+          gluon-gha-data/gluon patches/gluon
 
       - name: Fetch upstream tags
         # yamllint disable rule:line-length

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,21 +314,6 @@ jobs:
             "gluon-gha-data/gluon/output/images/other/*"
             "gluon-gha-data/gluon/output/images/factory/*"
 
-  # target job for required status check of build success
-  build-complete:
-    name: All Targets Build
-    runs-on: ubuntu-22.04
-    needs: [build, build-meta, targets]
-    if: ${{ !cancelled() }}
-    steps:
-      - name: Error out if there is a failure
-        if: ${{ needs.build.result != 'success' }}
-        run: |
-          echo "Build Matrix Result: ${{ needs.build.result }}"
-          exit 1
-      - name: All firmware builds succeded
-        run: echo "All firmware builds succeded!"
-
   manifest:
     needs: [build, build-meta, targets]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This adds the ability to add custom patches for Gluon to the Site
repository. These are applied pre-build to the Gluon tree and allow to
patch the repository without referencing an upstream fork in build-meta.

Signed-off-by: David Bauer <mail@david-bauer.net>