### PR TITLE
github: add ability to patch Gluon

### DIFF
--- a/.github/apply-site-patches.sh
+++ b/.github/apply-site-patches.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+REPO_PATH="$1"
+PATCHES_PATH="$(pwd)/$2"
+
+for patch in "$PATCHES_PATH"/*.patch; do
+	[ -e "$patch" ] || continue
+	echo "Applying patch $patch"
+	git -C "$REPO_PATH" am "$patch"
+done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,16 @@ jobs:
           ref: ${{ needs.build-meta.outputs.gluon-commit }}
           path: 'gluon-gha-data/gluon'
 
+      - name: Set Git config
+        run: |
+          git config --global user.name "Site CI"
+          git config --global user.email "site-ci@darmstadt.freifunk.net"
+
+      - name: Apply Site-Patches
+        run: >
+          bash .github/apply-site-patches.sh
+          gluon-gha-data/gluon patches/gluon
+
       - name: Determine Cache-Key
         id: cache-key
         run: >
@@ -217,6 +227,16 @@ jobs:
           path: 'gluon-gha-data/gluon'
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Set Git config
+        run: |
+          git config --global user.name "Site CI"
+          git config --global user.email "site-ci@darmstadt.freifunk.net"
+
+      - name: Apply Site-Patches
+        run: >
+          bash .github/apply-site-patches.sh
+          gluon-gha-data/gluon patches/gluon
 
       - name: Fetch upstream tags
         # yamllint disable rule:line-length


### PR DESCRIPTION
This adds the ability to add custom patches for Gluon to the Site repository. These are applied pre-build to the Gluon tree and allow to patch the repository without referencing an upstream fork in build-meta.


(cherry picked from commit e0e9ce727b401231044c78a024ab8254ed3d03e3)