### PR TITLE
build-info: update Gluon to 2025-11-19

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "8abad80deb907dd2900b8fddad5b4d49f687c1d0"
+        "commit": "0af1e351787aa2028bd77ed621ff4eb8f5da5e01"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 8abad80d to 0af1e351.

Supersedes #144 

~~~
0af1e351 net/l2tp: reset skb control buffer (#3614)
ddcd4371 Merge pull request #3431 from ffac/ng_wax206
b5d4bab3 Merge pull request #3600 from FGBxRamel/ax3000t
5baf5179 Merge pull request #3615 from achterin/feature/netgear_rbk50v1
fdccb9d5 Merge pull request #3611 from misanthropos/cudy-wr3000e
ad3f7237 ipq40xx-generic: add support for Netgear RBR50v1/RBS50v1
459330b5 mediatek-filogic: add cudy-wr3000e
38bc1b4c mediatek-mt7622: add support for netgear wax206
edda5a26 mediatek: Add support for Xiaomi AX3000T ubootmod
~~~