### PR TITLE
wifi: mt76: mt76x02: wake queues after reconfig

### DIFF
--- a/patches/gluon/500-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
+++ b/patches/gluon/500-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
@@ -1,0 +1,84 @@
+From de42848c1bb8b349aa74432695f3d61704e2d623 Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Mon, 24 Nov 2025 10:19:44 +0100
+Subject: [PATCH] wifi: mt76: mt76x02: wake queues after reconfig
+
+The shared reset procedure of MT7610 and MT7612 stop all queues before
+starting the reset sequence but never restartet these like other
+supported mt76 chips do in the reconfig_complete call.
+
+This leads to TX not continuing after the reset.
+
+Restart queues in the reconfig_complete callback to restore
+functionality after the reset.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+ ...6-mt76x02-wake-queues-after-reconfig.patch | 55 +++++++++++++++++++
+ 1 file changed, 55 insertions(+)
+ create mode 100644 patches/openwrt/0012-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
+
+diff --git a/patches/openwrt/0012-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch b/patches/openwrt/0012-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
+new file mode 100644
+index 00000000..d9c3cd76
+--- /dev/null
++++ b/patches/openwrt/0012-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
+@@ -0,0 +1,55 @@
++From: David Bauer <mail@david-bauer.net>
++Date: Mon, 24 Nov 2025 10:19:18 +0100
++Subject: wifi: mt76: mt76x02: wake queues after reconfig
++
++The shared reset procedure of MT7610 and MT7612 stop all queues before
++starting the reset sequence but never restartet these like other
++supported mt76 chips do in the reconfig_complete call.
++
++This leads to TX not continuing after the reset.
++
++Restart queues in the reconfig_complete callback to restore
++functionality after the reset.
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++
++diff --git a/package/kernel/mt76/patches/500-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch b/package/kernel/mt76/patches/500-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
++new file mode 100644
++index 0000000000000000000000000000000000000000..ca1c2246e9a4a95b8954407c55388213867bfe7b
++--- /dev/null
+++++ b/package/kernel/mt76/patches/500-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
++@@ -0,0 +1,34 @@
+++From e308e528fa54bbdad016bc076dedb9d3bf5229e8 Mon Sep 17 00:00:00 2001
+++From: David Bauer <mail@david-bauer.net>
+++Date: Mon, 24 Nov 2025 10:15:16 +0100
+++Subject: [PATCH] wifi: mt76: mt76x02: wake queues after reconfig
+++
+++The shared reset procedure of MT7610 and MT7612 stop all queues before
+++starting the reset sequence but never restartet these like other
+++supported mt76 chips do in the reconfig_complete call.
+++
+++This leads to TX not continuing after the reset.
+++
+++Restart queues in the reconfig_complete callback to restore
+++functionality after the reset.
+++
+++Signed-off-by: David Bauer <mail@david-bauer.net>
+++---
+++ mt76x02_mmio.c | 1 +
+++ 1 file changed, 1 insertion(+)
+++
+++diff --git a/mt76x02_mmio.c b/mt76x02_mmio.c
+++index dd71c1c9..dc7c03d2 100644
+++--- a/mt76x02_mmio.c
++++++ b/mt76x02_mmio.c
+++@@ -534,6 +534,7 @@ void mt76x02_reconfig_complete(struct ieee80211_hw *hw,
+++ 		return;
+++ 
+++ 	clear_bit(MT76_RESTART, &dev->mphy.state);
++++	ieee80211_wake_queues(hw);
+++ }
+++ EXPORT_SYMBOL_GPL(mt76x02_reconfig_complete);
+++ 
+++-- 
+++2.51.0
+++
+-- 
+2.51.0
+


### PR DESCRIPTION
The shared reset procedure of MT7610 and MT7612 stop all queues before starting the reset sequence but never restartet these like other supported mt76 chips do in the reconfig_complete call.

This leads to TX not continuing after the reset.

Restart queues in the reconfig_complete callback to restore functionality after the reset.