### PR TITLE
build-info: update Gluon to 2026-01-16

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "cbcbda747d3cca89006418a57539c4a4675452eb"
+        "commit": "955e155d834bcb7cf0e18ba2f26b786f9a5dd297"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from cbcbda74 to 955e155d.

https://github.com/freifunk-gluon/gluon/compare/cbcbda74...955e155d